### PR TITLE
# Add Check Transaction Status Button to Mpesa C2B Payment Register List View and Update Transaction Status API

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -203,9 +203,48 @@ def handle_transaction_status_result():
     try:
         response = frappe.request.data
         response_data = json.loads(response)
-        result_data = response_data.get("Result", {})
-        result_parameters = response_data.get("Result", {}).get("ResultParameters", {}).get("ResultParameter", [])
+
+        integration_request = frappe.get_doc({
+            "doctype": "Integration Request",
+            "is_remote_request": 1,
+            "integration_request_service": "Mpesa Transaction Status Result Callback",
+            "reference_doctype": "Mpesa C2B Payment Register",
+            "status": "Queued",
+            "data": json.dumps(response_data),
+            "url": frappe.request.url,
+            "method": "POST"
+        }).insert(ignore_permissions=True)
+        frappe.db.commit()
+
+        frappe.enqueue(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_mpesa_integration_request",
+            queue="short",
+            timeout=300,
+            job_id=f"mpesa_process_{integration_request.name}",
+            integration_request_name=integration_request.name,
+            deduplicate=True
+        )
+
+        return {"status": "queued", "message": "Transaction queued for processing"}
+    
+    except json.JSONDecodeError as e:
+        frappe.log_error(f"Failed to decode JSON from Mpesa response: {str(e)}", "Mpesa API Error")
+        return {"status": "error", "message": "Invalid JSON data"}
+    except Exception as e:
+        frappe.log_error(f"Error in Mpesa webhook: {str(e)}", "Mpesa API Error")
+        return {"status": "error", "message": f"Webhook error: {str(e)}"}
+         
+
+def process_mpesa_integration_request(integration_request_name):
+    """Process the Mpesa Integration Request and publish updates in real-time"""
+    try:
+        # Fetch the Integration Request
+        integration_request = frappe.get_doc("Integration Request", integration_request_name)
         
+        # Parse the stored data
+        response_data = json.loads(integration_request.data)
+        result_data = response_data.get("Result", {})
+        result_parameters = result_data.get("ResultParameters", {}).get("ResultParameter", [])
         result_params = {param.get("Key", ""): param.get("Value", "") for param in result_parameters if "Key" in param}
         
         result_code = result_data.get("ResultCode", None)
@@ -213,13 +252,22 @@ def handle_transaction_status_result():
         business_shortcode = result_params.get("CreditPartyName", "").split("-")
 
         if result_code == 0:
-
             if frappe.db.exists("Mpesa C2B Payment Register", {"transid": receipt_no}):
-                return {"status": "error", "message": f"Duplicate transaction: Receipt No {receipt_no} already exists"}
+                error_msg = f"Duplicate transaction: Receipt No {receipt_no} already exists"
+                integration_request.status = "Failed"
+                integration_request.output = error_msg
+                integration_request.save(ignore_permissions=True)
+                frappe.db.commit()
+                
+                frappe.publish_realtime(
+                    event="mpesa_transaction_status",
+                    message={"status": "error", "message": error_msg},
+                    user=frappe.session.user
+                )
+                return
             
-            # Map fields from the response to the DocType
+            # Create the Mpesa document
             mpesa_doc = frappe.new_doc("Mpesa C2B Payment Register")
-
             mpesa_doc.full_name = result_params.get("DebitPartyName", "")
             mpesa_doc.transactiontype = result_params.get("ReasonType", "")
             mpesa_doc.transid = result_params.get("ReceiptNo", "")
@@ -231,38 +279,56 @@ def handle_transaction_status_result():
             mpesa_doc.orgaccountbalance = result_params.get("DebitAccountType", "")
             mpesa_doc.thirdpartytransid = result_params.get("OriginatorConversationID", "")
 
-            # Extract MSISDN and Names Safely
             debit_party = result_params.get("DebitPartyName", "").split(" - ")
             mpesa_doc.msisdn = debit_party[0] if len(debit_party) > 0 else ""
-
             name_parts = debit_party[1].split(" ") if len(debit_party) > 1 else ["", "", ""]
             mpesa_doc.firstname = name_parts[0]
             mpesa_doc.middlename = name_parts[1] if len(name_parts) > 1 else ""
             mpesa_doc.lastname = name_parts[-1] if len(name_parts) > 2 else ""
 
-            # Insert and commit changes
             mpesa_doc.insert(ignore_permissions=True)
             frappe.db.commit()
 
-            return {"status": "success", "message": "Transaction processed successfully"}
+            success_msg = "Transaction processed successfully"
+            integration_request.status = "Completed"
+            integration_request.output = success_msg
+            integration_request.reference_document = mpesa_doc.name
+            integration_request.save(ignore_permissions=True)
+            frappe.db.commit()
+
+            frappe.publish_realtime(
+                event="mpesa_transaction_status",
+                message={"status": "success", "message": success_msg, "doc_name": mpesa_doc.name},
+                user=frappe.session.user
+            )
         
         else:
+            error_msg = "Transaction failed with non-zero result code"
+            integration_request.status = "Failed"
+            integration_request.output = error_msg
+            integration_request.save(ignore_permissions=True)
+            frappe.db.commit()
 
-            return {"status": "error", "message": "Failed successfully"}
-    
-    except json.JSONDecodeError as e:
-
-        frappe.log_error(f"Failed to decode JSON from Mpesa response: {str(e)}", "Mpesa API Error")
-        return {"status": "error", "message": "Invalid JSON data"}
+            frappe.publish_realtime(
+                event="mpesa_transaction_status",
+                message={"status": "error", "message": error_msg},
+                user=frappe.session.user
+            )
 
     except Exception as e:
-        
-        error_message = f"Mpesa Transaction Status Error: {str(e)}"
+        error_message = f"Mpesa Processing Error: {str(e)}"
+        integration_request.status = "Failed"
+        integration_request.output = error_message
+        integration_request.save(ignore_permissions=True)
+        frappe.db.commit()
 
-        if len(response_data) > 140:
-            response_data = json.dumps(response_data)[:100] + "..."
-        frappe.log_error(f"{error_message}\nResponse: {response_data}", "Mpesa API Error")
-        return {"status": "error", "message": error_message}    
+        frappe.log_error(f"{error_message}\nData: {integration_request.data}", "Mpesa Integration Error")
+        frappe.publish_realtime(
+            event="mpesa_transaction_status",
+            message={"status": "error", "message": error_message},
+            user=frappe.session.user
+        )
+
 
 @frappe.whitelist(allow_guest=True)
 def handle_queue_timeout():

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
@@ -1,0 +1,78 @@
+frappe.listview_settings['Mpesa C2B Payment Register'] = {
+    onload: function(listview) {
+        // Add a custom button to the page actions (top bar)
+        listview.page.add_inner_button(__("Check Transaction Status"), function() {
+            frappe.prompt(
+                [
+                    {
+                        label: "Mpesa Settings",
+                        fieldname: "mpesa_settings",
+                        fieldtype: "Link",
+                        options: "Mpesa Settings",
+                        reqd: 1
+                    },
+                    {
+                        label: "Transaction ID",
+                        fieldname: "transaction_id",
+                        fieldtype: "Data",
+                        reqd: 1
+                    },
+                    {
+                        label: "Remarks",
+                        fieldname: "remarks",
+                        fieldtype: "Small Text"
+                    }
+                ],
+                (values) => {
+                    frappe.db.get_value("Mpesa Settings", values.mpesa_settings, ["initiator_name", "security_credential"], (settings) => {
+                        if (!settings || (!settings.initiator_name && !settings.security_credential)) {
+                            frappe.throw(__("Please set the initiator name and security credential in the selected Mpesa Settings"));
+                        }
+
+                        frappe.call({
+                            method: "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.trigger_transaction_status",
+                            args: {
+                                mpesa_settings: values.mpesa_settings,
+                                transaction_id: values.transaction_id,
+                                remarks: values.remarks
+                            },
+                            callback: (r) => {
+                                if (r.message && r.message.status === "queued") {
+                                    // Wait for the transaction status to be processed
+                                } else {
+                                    frappe.msgprint({
+                                        message: __(r.message.message),
+                                        title: r.message.status === "error" ? "Error" : "Success",
+                                        indicator: r.message.status === "error" ? "red" : "green"
+                                    });
+                                }
+                            },
+                            error: (err) => {
+                                frappe.msgprint({
+                                    message: __("An error occurred: {0}", [err.message]),
+                                    title: "Error",
+                                    indicator: "red"
+                                });
+                            }
+                        });
+                    });
+                },
+                __("Transaction Status Query"),
+                __("Submit")
+            );
+        });
+    },
+
+    refresh: function(listview) {
+        frappe.realtime.on("mpesa_transaction_status", function(data) {
+            frappe.msgprint({
+                message: __(data.message),
+                title: data.status === "success" ? "Success" : "Error",
+                indicator: data.status === "success" ? "green" : "red"
+            });
+            if (data.status === "success" && data.doc_name) {
+                listview.refresh();
+            }
+        });
+    }
+};

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -11,6 +11,15 @@ frappe.ui.form.on('Mpesa Settings', {
 			frm.reload_doc();
 			frm.events.setup_account_balance_html(frm);
 		});
+
+		frappe.realtime.on("mpesa_transaction_status", function(data) {
+            console.log("Real-time update received:", data);
+            frappe.msgprint({
+                message: __(data.message),
+                title: data.status === "success" ? "Success" : "Error",
+                indicator: data.status === "success" ? "green" : "red"
+            });
+        });
 	},
 
 	get_account_balance: function(frm) {
@@ -35,8 +44,8 @@ frappe.ui.form.on('Mpesa Settings', {
 	},
 
 	check_transaction_status: function(frm) {
-		if (!frm.doc.initiator_name && !frm.doc.initiator_password) {
-			frappe.throw(__("Please set the initiator name and the initiator password"));
+		if (!frm.doc.initiator_name && !frm.doc.security_credential) {
+			frappe.throw(__("Please set the initiator name and the security credential"));
 		}
 		frappe.clear_cache;
 		frappe.prompt(
@@ -62,26 +71,26 @@ frappe.ui.form.on('Mpesa Settings', {
 						remarks: values.remarks
 					},
 					callback: (r) => {
-						if (r.message) {
-							if (r.message.ResponseCode === "0") {
-								frappe.msgprint({
-									message: __("Transaction Status: {0}", [r.message.ResponseDescription]),
-									title: "Success",
-									indicator: "green",
-								});
-							} else {
-								frappe.msgprint({
-									message: r.message.errorCode + ": " + r.message.errorMessage,
-									title: "Error",
-									indicator: "red",
-								});
-							}
+						if (r.message && r.message.status === "queued") {
+						} else {
+							frappe.msgprint({
+								message: __(r.message.message),
+								title: r.message.status === "error" ? "Error" : "Success",
+								indicator: r.message.status === "error" ? "red" : "green"
+							});
 						}
+					},
+					error: (err) => {
+						frappe.msgprint({
+							message: __("An error occurred: {0}", [err.message]),
+							title: "Error",
+							indicator: "red"
+						});
 					}
 				});
 			},
 			__("Transaction Status Query"),
 			__("Submit")
 		);
-	}
+	},
 });

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -12,7 +12,6 @@
   "sandbox",
   "section_break_lkry",
   "initiator_name",
-  "initiator_password",
   "consumer_key",
   "consumer_secret",
   "security_credential",
@@ -124,18 +123,13 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "initiator_password",
-   "fieldtype": "Password",
-   "label": "Initiator Password"
-  },
-  {
    "fieldname": "check_transaction_status",
    "fieldtype": "Button",
    "label": "Check Transaction Status"
   }
  ],
  "links": [],
- "modified": "2025-02-18 11:17:04.338605",
+ "modified": "2025-03-04 09:42:54.120902",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -403,20 +403,64 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
         site_address = get_request_site_address(True)
         parsed_url = urlparse(site_address)
         site_url = f"{parsed_url.scheme}://{parsed_url.hostname}"
-                
-        # Retrieve the public certificate path from the Mpesa Public Key Certificate doctype
-        certificate_type = "sandbox_certificate" if settings.sandbox else "production_certificate"
-        public_cert_path = frappe.db.get_single_value("Mpesa Public Key Certificate", certificate_type)
-
-        if not public_cert_path:
-            frappe.throw(f"Certificate file for {certificate_type} not found in {get_link_to_form(r'Mpesa Public Key Certificate', r'Mpesa Public Key Certificate')} doctype.")
-                            
-        # Generate security credential
-        security_credential = generate_security_credential(settings.get_password("initiator_password"), public_cert_path)
 
         queue_timeout_url = site_url + "/api/method/frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.handle_queue_timeout"
         result_url = site_url + "/api/method/frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.handle_transaction_status_result"
 
+        integration_request = frappe.get_doc({
+            "doctype": "Integration Request",
+            "is_remote_request": 1,
+            "integration_request_service": "Mpesa Transaction Status",
+            "reference_doctype": "Mpesa C2B Payment Register",
+            "status": "Queued",
+            "data": dumps({
+                "mpesa_settings": mpesa_settings,
+                "transaction_id": transaction_id,
+                "remarks": remarks,
+                "queue_timeout_url": queue_timeout_url,
+                "result_url": result_url
+            }),
+            "method": "POST"
+        }).insert(ignore_permissions=True)
+        frappe.db.commit()
+
+        frappe.enqueue(
+            "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.process_transaction_status",
+            queue="short",
+            timeout=300,
+            job_id=f"mpesa_status_{integration_request.name}",
+            integration_request_name=integration_request.name,
+            deduplicate=True
+        )
+
+        frappe.publish_realtime(
+            event="mpesa_transaction_status",
+            message={"status": "queued", "message": _("Transaction status check queued for processing")},
+            user=frappe.session.user
+        )
+        return {"status": "queued", "message": "Transaction status check queued"}
+
+    except Exception as e:
+        frappe.log_error(title="Mpesa Transaction Status Queue Error", message=str(e))
+        return {"status": "error", "message": str(e)}
+
+
+def process_transaction_status(integration_request_name):
+    """Process the Mpesa transaction status check in the background"""
+    try:
+
+        integration_request = frappe.get_doc("Integration Request", integration_request_name)
+        data = loads(integration_request.data)
+
+        mpesa_settings = data["mpesa_settings"]
+        transaction_id = data["transaction_id"]
+        remarks = data["remarks"]
+        queue_timeout_url = data["queue_timeout_url"]
+        result_url = data["result_url"]
+
+        settings = frappe.get_doc("Mpesa Settings", mpesa_settings)
+
+        # Initialize Mpesa Connector
         connector = MpesaConnector(
             env="production" if not settings.sandbox else "sandbox",
             app_key=settings.consumer_key,
@@ -425,16 +469,52 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
 
         response = connector.transaction_status(
             initiator=settings.initiator_name,
-            security_credential=security_credential,
+            security_credential=settings.security_credential,
             transaction_id=transaction_id,
             party_a=settings.business_shortcode if not settings.sandbox else settings.till_number,
-            identifier_type=4,  # Assuming Organization Short Code
+            identifier_type=4,  # Organization Short Code
             remarks=remarks,
             occasion="",
             queue_timeout_url=queue_timeout_url,
             result_url=result_url
         )
-        return response
+
+        if response.get("ResponseCode") == "0":
+            integration_request.status = "Completed"
+            integration_request.output = dumps(response)
+            integration_request.save(ignore_permissions=True)
+            frappe.db.commit()
+
+            frappe.publish_realtime(
+                event="mpesa_transaction_status",
+                message={
+                    "status": "success",
+                    "message": f"Transaction Status: {response.get('ResponseDescription')}"
+                },
+                user=frappe.session.user
+            )
+        else:
+            error_msg = f"{response.get('errorCode', 'Unknown')}: {response.get('errorMessage', 'Unknown error')}"
+            integration_request.status = "Failed"
+            integration_request.output = error_msg
+            integration_request.save(ignore_permissions=True)
+            frappe.db.commit()
+
+            frappe.publish_realtime(
+                event="mpesa_transaction_status",
+                message={"status": "error", "message": error_msg},
+                user=frappe.session.user
+            )
+
     except Exception as e:
-        frappe.log_error(title="Mpesa Transaction Status Error", message=str(e))
-        return {"status": "error", "message": str(e)}
+        integration_request.status = "Failed"
+        integration_request.output = str(e)
+        integration_request.save(ignore_permissions=True)
+        frappe.db.commit()
+
+        frappe.log_error(title="Mpesa Transaction Status Process Error", message=str(e))
+        frappe.publish_realtime(
+            event="mpesa_transaction_status",
+            message={"status": "error", "message": f"Error checking status: {str(e)}"},
+            user=frappe.session.user
+        )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/workspace/mpesa/mpesa.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/workspace/mpesa/mpesa.json
@@ -1,7 +1,7 @@
 {
  "charts": [],
- "content": "[{\"id\":\"NCFKBQmrd4\",\"type\":\"card\",\"data\":{\"card_name\":\"Mpesa\",\"col\":4}}]",
- "creation": "2025-02-17 08:04:20.157928",
+ "content": "[{\"id\":\"nu2bkf51Ir\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Mpesa</span>\",\"col\":12}},{\"id\":\"wpupG131up\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"vf0kf-mCfu\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Configurations</b></span>\",\"col\":6}},{\"id\":\"Z_7QeXNH1Q\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Payments</b></span>\",\"col\":6}},{\"id\":\"3MP5wad0YH\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa Settings\",\"col\":6}},{\"id\":\"O9RAIWJMwq\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa C2B Payment Register\",\"col\":6}},{\"id\":\"XvfvPaM0Om\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa C2B Payment Register URL\",\"col\":6}},{\"id\":\"Y5fdZwXWPe\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa Payment Reconciliation\",\"col\":6}},{\"id\":\"lXslUPOYRR\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa Public Key Certificate\",\"col\":6}}]",
+ "creation": "2025-03-06 09:26:13.194859",
  "custom_blocks": [],
  "docstatus": 0,
  "doctype": "Workspace",
@@ -9,121 +9,11 @@
  "hide_custom": 0,
  "icon": "money-coins-1",
  "idx": 0,
- "indicator_color": "",
+ "indicator_color": "green",
  "is_hidden": 0,
  "label": "Mpesa",
- "links": [
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa Settings",
-   "link_count": 0,
-   "link_to": "Mpesa Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa C2B Payment Register",
-   "link_count": 0,
-   "link_to": "Mpesa C2B Payment Register",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa C2B Payment Register URL",
-   "link_count": 0,
-   "link_to": "Mpesa C2B Payment Register URL",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa Public Key Certificate",
-   "link_count": 0,
-   "link_to": "Mpesa Public Key Certificate",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa Payment Reconciliation",
-   "link_count": 0,
-   "link_to": "Mpesa Payment Reconciliation",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa",
-   "link_count": 5,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa Settings",
-   "link_count": 0,
-   "link_to": "Mpesa Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa C2B Payment Register URL",
-   "link_count": 0,
-   "link_to": "Mpesa C2B Payment Register URL",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa C2B Payment Register",
-   "link_count": 0,
-   "link_to": "Mpesa C2B Payment Register",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa Public Key Certificate",
-   "link_count": 0,
-   "link_to": "Mpesa Public Key Certificate",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa Payment Reconciliation",
-   "link_count": 0,
-   "link_to": "Mpesa Payment Reconciliation",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  }
- ],
- "modified": "2025-02-17 08:11:20.924151",
+ "links": [],
+ "modified": "2025-03-06 09:36:10.001167",
  "modified_by": "mwendwa@navari.co.ke",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa",
@@ -134,6 +24,45 @@
  "quick_lists": [],
  "roles": [],
  "sequence_id": 48.0,
- "shortcuts": [],
+ "shortcuts": [
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Mpesa Settings",
+   "link_to": "Mpesa Settings",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Mpesa C2B Payment Register",
+   "link_to": "Mpesa C2B Payment Register",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Mpesa C2B Payment Register URL",
+   "link_to": "Mpesa C2B Payment Register URL",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Mpesa Payment Reconciliation",
+   "link_to": "Mpesa Payment Reconciliation",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Mpesa Public Key Certificate",
+   "link_to": "Mpesa Public Key Certificate",
+   "type": "DocType"
+  }
+ ],
  "title": "Mpesa"
 }


### PR DESCRIPTION
## Description
This PR introduces a "Check Transaction Status" button to the `Mpesa C2B Payment Register` list view, enhancing usability for payment management. It also refactors the Mpesa Transaction Status API integration by switching to `security_credential` from `initiator_password`, removing the latter field, and adopting `Integration Requests` with `frappe.enqueue` for background processing. These changes improve reliability, security, and user experience.

### Changes
- **Check Transaction Status Button**:
  - Added a custom "Check Transaction Status" button to the `Mpesa C2B Payment Register` list view using `frappe.listview_settings['Mpesa C2B Payment Register'].onload`.

![image](https://github.com/user-attachments/assets/0c9bbae2-c106-4b7e-8caf-46cf3bbf43f7)

  - On click, it prompts the user to select an `Mpesa Settings` document (Link field), enter a `Transaction ID`, and optionally provide `Remarks`.

![image](https://github.com/user-attachments/assets/53d7d2b9-d4d7-486a-924c-dc3939b0898e)

  - Validates `initiator_name` and `security_credential` from the selected `Mpesa Settings` .
  - Calls `trigger_transaction_status` function with the provided inputs.
  - Displays a "queued" message (blue) and leverages real-time updates via the `mpesa_transaction_status` event to show success/error messages.
  - Refreshes the list view on successful transaction creation (if a new document is added).

![image](https://github.com/user-attachments/assets/58f4c1b6-9b1a-4d2c-8238-4d09d46acacb)


- **Real-Time Messaging**:
  - Integrated `frappe.realtime.on("mpesa_transaction_status", ...)` in the list view’s `refresh` handler to provide immediate feedback (success/error messages) to the user.

- **Switch to `security_credential`**:
  - Updated `trigger_transaction_status` to use the `security_credential` field from `Mpesa Settings` directly, replacing the previous approach of encrypting `initiator_password` using a public certificate.

- **Remove `initiator_password`**:
  - Deleted the `initiator_password` field from the `Mpesa Settings` DocType, as it’s no longer required with the switch to `security_credential`.
  - Updated related client-side validation (e.g., in `Mpesa Settings` and `Mpesa C2B Payment Register` scripts) to check `security_credential` instead.
  - 
- **Integration Requests and Background Tasks**:
  - Refactored `trigger_transaction_status` to create an `Integration Request` and enqueue its processing via `frappe.enqueue` to `process_transaction_status`.
  - Added `process_transaction_status` to handle the Mpesa API call in the background, updating the `Integration Request` status (`Queued` → `Completed`/`Failed`) and publishing real-time updates.
