### PR TITLE
Mpesa express enhancements

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -269,7 +269,8 @@ def initiate_stk_push(**args) -> any:
             "Timestamp": timestamp,
             "Amount": amount,
             "PartyA": int(mobile_number),
-            "PartyB": business_shortcode,
+            "PartyB": business_shortcode if mpesa_settings.paybill_type == "Pay Bill"
+            else mpesa_settings.till_number,
             "PhoneNumber": int(mobile_number),
             "CallBackURL": callback_url,
             "AccountReference": reference_name,
@@ -323,7 +324,8 @@ def stk_push_callback(**kwargs) -> None:
             payment_entry.create_payment_entry()
         except Exception:
             frappe.log_error(frappe.get_traceback(), f"Payment Entry Creation Error: {checkout_request_id}")
-        payment_entry.make_invoice()
+        if request_doc.reference_doctype == "Sales Order":
+            payment_entry.make_invoice()
         frappe.db.set_value("Payment Request", payment_entry.name, "status", "Paid")
 
     frappe.db.set_value(MPESA_EXPRESS_REQUEST_DOCTYPE, request_doc.name, {

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -28,7 +28,9 @@ def transaction_status_on_success(response: dict, document_name: str, **kwargs) 
                 payment_entry.create_payment_entry()
             except Exception:
                 frappe.log_error(frappe.get_traceback(), f"Payment Entry Creation Error: {document_name}")
-            payment_entry.make_invoice()
+                
+            if request_doc.reference_doctype == "Sales Order":
+                payment_entry.make_invoice()
             frappe.db.set_value("Payment Request", payment_entry.name, "status", "Paid")
 
         # Update the database record

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -104,8 +104,7 @@
   {
    "fieldname": "security_credential",
    "fieldtype": "Small Text",
-   "label": "Security Credential",
-   "mandatory_depends_on": "eval:(doc.api_type === \"MPesa B2C (Business to Customer)\");"
+   "label": "Security Credential"
   },
   {
    "fieldname": "get_account_balance",
@@ -260,7 +259,7 @@
   }
  ],
  "links": [],
- "modified": "2025-04-08 16:58:52.608835",
+ "modified": "2025-04-08 17:08:10.478156",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -20,6 +20,7 @@
   "security_credential",
   "column_break_4",
   "business_shortcode",
+  "till_number",
   "online_passkey",
   "transaction_limit",
   "initiator_name",
@@ -249,10 +250,17 @@
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company"
+  },
+  {
+   "depends_on": "eval:doc.paybill_type == \"Buy Goods\"",
+   "fieldname": "till_number",
+   "fieldtype": "Data",
+   "label": "Till Number",
+   "mandatory_depends_on": "eval:doc.paybill_type == \"Buy Goods\""
   }
  ],
  "links": [],
- "modified": "2025-03-26 20:06:08.344077",
+ "modified": "2025-04-08 16:58:52.608835",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -123,7 +123,7 @@ class MpesaSettings(Document):
                 stk_request = frappe.new_doc(MPESA_EXPRESS_REQUEST_DOCTYPE)
                 stk_request.update({
                     "amount": args.get("request_amount", 0.0),
-                    "phone_number": args.get("phone_number", ""),
+                    "phone_number": args.get("phone_number") or args.get("sender", ""),
                     "timestamp": frappe.utils.now(),
                     "settings": args.payment_gateway[6:],
                     "payment_gateway": args.get("payment_gateway"),

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -107,6 +107,20 @@ class MpesaSettings(Document):
         create_mode_of_payment(
             "Mpesa-" + self.payment_gateway_name, payment_type="Phone", company=self.company
         )
+        
+    def validate(self) -> None:   
+        if self.initiator_password and not self.security_credential:     
+            certs = frappe.get_single("Mpesa Public Key Certificate")
+            cert_url = ""
+            if self.sandbox:
+                cert_url = certs.sandbox_certificate
+            else:
+                cert_url = certs.production_certificate
+                
+            self.security_credential = generate_security_credential(
+                self.get_password("initiator_password", "") if self.initiator_password else "",
+                cert_url
+            )
 
     def request_for_payment(self, **kwargs) -> None:
         args = frappe._dict(kwargs)


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `frappe_mpsa_payments` module, focusing on improving the handling of MPesa payments and settings. The key changes include updates to the `initiate_stk_push` function, enhancements to the `mpesa_settings` doctype, and additional validation logic.

### Enhancements to MPesa Payment Handling:

* [`frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py`](diffhunk://#diff-a86a14acba94754d356dbf7e906a64cdf7993fce5c4a83e8ba3de94ccac1d050L272-R273): Updated `initiate_stk_push` to conditionally use `business_shortcode` or `till_number` based on the `paybill_type` setting.
* [`frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py`](diffhunk://#diff-a86a14acba94754d356dbf7e906a64cdf7993fce5c4a83e8ba3de94ccac1d050R327): Modified `stk_push_callback` to create an invoice if the `reference_doctype` is "Sales Order".
* [`frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py`](diffhunk://#diff-c211cd27aeac3866d2e321889e4001a230a08a17463c7c80ebde1dacf5550c2cR31-R32): Added logic to `transaction_status_on_success` to create an invoice if the `reference_doctype` is "Sales Order".

### Enhancements to MPesa Settings:

* [`frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json`](diffhunk://#diff-9bcdb925d9bf2e786a2c8c706f83b6a6bb4eb9586f1df2920d4c161fb5e5c92aR23): Added a new field `till_number` and updated the `security_credential` field to remove the `mandatory_depends_on` condition. [[1]](diffhunk://#diff-9bcdb925d9bf2e786a2c8c706f83b6a6bb4eb9586f1df2920d4c161fb5e5c92aR23) [[2]](diffhunk://#diff-9bcdb925d9bf2e786a2c8c706f83b6a6bb4eb9586f1df2920d4c161fb5e5c92aL106-R107) [[3]](diffhunk://#diff-9bcdb925d9bf2e786a2c8c706f83b6a6bb4eb9586f1df2920d4c161fb5e5c92aR252-R262)
* [`frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py`](diffhunk://#diff-feb606bbeac687b4193ea29571448f17c8672c4f94aa7a5a66072f4a3531842aR111-R124): Introduced a `validate` method to automatically generate the `security_credential` if the `initiator_password` is provided.

### Minor Fixes:

* [`frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py`](diffhunk://#diff-feb606bbeac687b4193ea29571448f17c8672c4f94aa7a5a66072f4a3531842aL126-R140): Updated `request_for_payment` to handle both `phone_number` and `sender` fields.