### PR TITLE
improve billrefnumber matching logic to include more transaction sources

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register.py
@@ -118,20 +118,22 @@ class MpesaC2BPaymentRegister(Document):
         if not billrefnumber:
             return
 
-        customer_from_invoice = frappe.get_value(
-            "Sales Invoice",
-            {"name": billrefnumber, "docstatus": 1},
-            "customer"
-        )
+        sources = [
+            ("Sales Invoice", "customer", {"docstatus": 1}),
+            ("Sales Order", "customer", {"docstatus": 1}),
+            ("Quotation", "party_name", {"docstatus": 1, "quotation_to": "Customer"}),
+            ("Customer", "name", {})
+        ]
 
-        if customer_from_invoice:
-            self.customer = customer_from_invoice
-            return
+        for doctype, customer_field, extra_filters in sources:
+            filters = {"name": billrefnumber}
+            filters.update(extra_filters)
 
-        customer = frappe.get_value(
-            "Customer",
-            {"name": billrefnumber},
-            "name"
-        )    
-        if customer:
-            self.customer = customer
+            customer = frappe.db.get_value(
+                doctype,
+                filters,
+                customer_field
+            )
+            if customer:
+                self.customer = customer
+                return


### PR DESCRIPTION
- Enhanced the logic for resolving the customer from `billrefnumber` in incoming C2B payments.
- Added support for matching across multiple document types:
  - Sales Invoice
  - Sales Order
  - Quotation (limited to `quotation_to = "Customer"`)
  - Customer (as a fallback)
- This ensures more reliable customer assignment when reconciling M-Pesa payments, especially in cases where payments are linked to quotations or orders instead of just invoices.