### PR TITLE
Feat: B2C Disbursement Summary Report

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -29,7 +29,32 @@ frappe.query_reports['B2C Disbursement Summary'] = {
       fieldname: 'party_type',
       label: __('Party Type'),
       fieldtype: 'Select',
-      options: '\nEmployee\nSupplier\nCustomer',
+      options: '\nEmployee\nSupplier',
+    },
+    {
+      fieldname: 'party',
+      label: __('Party'),
+      fieldtype: 'Dynamic Link',
+      options: 'party_type',
+      depends_on: 'eval:doc.party_type',
+      mandatory_depends_on: 'eval:doc.party_type',
+    },
+    {
+      fieldname: 'transaction_to_pay_against',
+      label: __('Transaction to Pay Against'),
+      fieldtype: 'Link',
+      options: 'DocType',
+      get_query: function () {
+        const doctypes =
+          frappe.query_report.get_filter_value('party_type') === 'Employee'
+            ? ['Salary Slip', 'Employee Advance', 'Expense Claim', 'Loan']
+            : ['Purchase Invoice', 'Purchase Order'];
+        return {
+          filters: {
+            name: ['in', doctypes],
+          },
+        };
+      },
     },
   ],
   formatter: function (value, row, column, data, default_formatter) {

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Navari Limited and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["B2C Disbursement Summary"] = {
+	"filters": [
+
+	]
+};

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -32,4 +32,31 @@ frappe.query_reports['B2C Disbursement Summary'] = {
       options: '\nEmployee\nSupplier\nCustomer',
     },
   ],
+  formatter: function (value, row, column, data, default_formatter) {
+    let formatted_value = default_formatter(value, row, column, data);
+
+    if (data && data.is_subtotal) {
+      formatted_value = `<span style="font-weight: bold;">${formatted_value}</span>`;
+    }
+
+    const blankFields = ['total_amount'];
+
+    const isBlankableColumn =
+      blankFields.includes(column.fieldname) || /\d+$/.test(column.fieldname);
+
+    const shouldBlank =
+      data &&
+      (value === null ||
+        value === undefined ||
+        value === '' ||
+        value === 0 ||
+        value === '0%' ||
+        formatted_value === 'Sh 0.00');
+
+    if (isBlankableColumn && shouldBlank) {
+      return '';
+    }
+
+    return formatted_value;
+  },
 };

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -1,64 +1,64 @@
 // Copyright (c) 2025, Navari Limited and contributors
 // For license information, please see license.txt
 
-frappe.query_reports['B2C Disbursement Summary'] = {
+frappe.query_reports["B2C Disbursement Summary"] = {
   filters: [
     {
-      fieldname: 'company',
-      label: __('Company'),
-      fieldtype: 'Link',
-      options: 'Company',
+      fieldname: "company",
+      label: __("Company"),
+      fieldtype: "Link",
+      options: "Company",
       reqd: 1,
-      default: frappe.defaults.get_user_default('Company'),
+      default: frappe.defaults.get_user_default("Company"),
     },
     {
-      fieldname: 'start_date',
-      label: __('Start Date'),
-      fieldtype: 'Date',
+      fieldname: "start_date",
+      label: __("Start Date"),
+      fieldtype: "Date",
       default: frappe.datetime.add_months(frappe.datetime.get_today(), -5),
       reqd: 1,
     },
     {
-      fieldname: 'end_date',
-      label: __('End Date'),
-      fieldtype: 'Date',
+      fieldname: "end_date",
+      label: __("End Date"),
+      fieldtype: "Date",
       default: frappe.datetime.get_today(),
       reqd: 1,
     },
     {
-      fieldname: 'party_type',
-      label: __('Party Type'),
-      fieldtype: 'Link',
-      options: 'DocType',
+      fieldname: "party_type",
+      label: __("Party Type"),
+      fieldtype: "Link",
+      options: "DocType",
       get_query: function () {
         return {
           filters: {
-            name: ['in', ['Supplier', 'Employee']],
+            name: ["in", ["Supplier", "Employee"]],
           },
         };
       },
     },
     {
-      fieldname: 'party',
-      label: __('Party'),
-      fieldtype: 'Dynamic Link',
-      options: 'party_type',
-      depends_on: 'eval:doc.party_type',
-      mandatory_depends_on: 'eval:doc.party_type',
+      fieldname: "party",
+      label: __("Party"),
+      fieldtype: "Dynamic Link",
+      options: "party_type",
+      depends_on: "eval:doc.party_type",
+      mandatory_depends_on: "eval:doc.party_type",
     },
     {
-      fieldname: 'transaction_to_pay_against',
-      label: __('Transaction to Pay Against'),
-      fieldtype: 'Link',
-      options: 'DocType',
+      fieldname: "transaction_to_pay_against",
+      label: __("Transaction to Pay Against"),
+      fieldtype: "Link",
+      options: "DocType",
       get_query: function () {
         const doctypes =
-          frappe.query_report.get_filter_value('party_type') === 'Employee'
-            ? ['Salary Slip', 'Employee Advance', 'Expense Claim', 'Loan']
-            : ['Purchase Invoice', 'Purchase Order'];
+          frappe.query_report.get_filter_value("party_type") === "Employee"
+            ? ["Salary Slip", "Employee Advance", "Expense Claim", "Loan"]
+            : ["Purchase Invoice", "Purchase Order"];
         return {
           filters: {
-            name: ['in', doctypes],
+            name: ["in", doctypes],
           },
         };
       },
@@ -71,7 +71,7 @@ frappe.query_reports['B2C Disbursement Summary'] = {
       formatted_value = `<span style="font-weight: bold;">${formatted_value}</span>`;
     }
 
-    const blankFields = ['total_amount'];
+    const blankFields = ["total_amount"];
 
     const isBlankableColumn =
       blankFields.includes(column.fieldname) || /\d+$/.test(column.fieldname);
@@ -80,13 +80,13 @@ frappe.query_reports['B2C Disbursement Summary'] = {
       data &&
       (value === null ||
         value === undefined ||
-        value === '' ||
+        value === "" ||
         value === 0 ||
-        value === '0%' ||
-        formatted_value === 'Sh 0.00');
+        value === "0%" ||
+        formatted_value === "Sh 0.00");
 
     if (isBlankableColumn && shouldBlank) {
-      return '';
+      return "";
     }
 
     return formatted_value;

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -22,7 +22,7 @@ frappe.query_reports['B2C Disbursement Summary'] = {
       label: __('Company'),
       fieldtype: 'Link',
       options: 'Company',
-      required: 1,
+      reqd: 1,
       default: frappe.defaults.get_user_default('Company'),
     },
     {

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -28,8 +28,15 @@ frappe.query_reports['B2C Disbursement Summary'] = {
     {
       fieldname: 'party_type',
       label: __('Party Type'),
-      fieldtype: 'Select',
-      options: '\nEmployee\nSupplier',
+      fieldtype: 'Link',
+      options: 'DocType',
+      get_query: function () {
+        return {
+          filters: {
+            name: ['in', ['Supplier', 'Employee']],
+          },
+        };
+      },
     },
     {
       fieldname: 'party',

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -4,6 +4,14 @@
 frappe.query_reports['B2C Disbursement Summary'] = {
   filters: [
     {
+      fieldname: 'company',
+      label: __('Company'),
+      fieldtype: 'Link',
+      options: 'Company',
+      reqd: 1,
+      default: frappe.defaults.get_user_default('Company'),
+    },
+    {
       fieldname: 'start_date',
       label: __('Start Date'),
       fieldtype: 'Date',
@@ -16,14 +24,6 @@ frappe.query_reports['B2C Disbursement Summary'] = {
       fieldtype: 'Date',
       default: frappe.datetime.get_today(),
       reqd: 1,
-    },
-    {
-      fieldname: 'company',
-      label: __('Company'),
-      fieldtype: 'Link',
-      options: 'Company',
-      reqd: 1,
-      default: frappe.defaults.get_user_default('Company'),
     },
     {
       fieldname: 'party_type',

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -1,8 +1,35 @@
 // Copyright (c) 2025, Navari Limited and contributors
 // For license information, please see license.txt
 
-frappe.query_reports["B2C Disbursement Summary"] = {
-	"filters": [
-
-	]
+frappe.query_reports['B2C Disbursement Summary'] = {
+  filters: [
+    {
+      fieldname: 'start_date',
+      label: __('Start Date'),
+      fieldtype: 'Date',
+      default: frappe.datetime.add_months(frappe.datetime.get_today(), -5),
+      reqd: 1,
+    },
+    {
+      fieldname: 'end_date',
+      label: __('End Date'),
+      fieldtype: 'Date',
+      default: frappe.datetime.get_today(),
+      reqd: 1,
+    },
+    {
+      fieldname: 'company',
+      label: __('Company'),
+      fieldtype: 'Link',
+      options: 'Company',
+      required: 1,
+      default: frappe.defaults.get_user_default('Company'),
+    },
+    {
+      fieldname: 'party_type',
+      label: __('Party Type'),
+      fieldtype: 'Select',
+      options: '\nEmployee\nSupplier\nCustomer',
+    },
+  ],
 };

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -43,6 +43,18 @@ frappe.query_reports["B2C Disbursement Summary"] = {
       label: __("Party"),
       fieldtype: "Dynamic Link",
       options: "party_type",
+      get_query: function () {
+        const selected_party_type =
+          frappe.query_report.get_filter_value("party_type");
+
+        if (selected_party_type == "Employee") {
+          return {
+            filters: {
+              status: "Active",
+            },
+          };
+        }
+      },
       depends_on: "eval:doc.party_type",
       mandatory_depends_on: "eval:doc.party_type",
     },

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.json
@@ -1,0 +1,35 @@
+{
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-06-26 00:51:01.546892",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letter_head": "Default",
+ "letterhead": null,
+ "modified": "2025-06-26 00:51:01.546892",
+ "modified_by": "Administrator",
+ "module": "Frappe Mpsa Payments",
+ "name": "B2C Disbursement Summary",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "B2C Payment Disbursement",
+ "report_name": "B2C Disbursement Summary",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Accounts Manager"
+  },
+  {
+   "role": "HR Manager"
+  }
+ ],
+ "timeout": 0
+}

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -5,5 +5,71 @@
 
 
 def execute(filters=None):
-	columns, data = [], []
-	return columns, data
+    columns = get_columns()
+    columns = get_data(filters)
+
+    return columns, data
+
+
+def get_columns():
+    return [
+        {
+            "fieldname": "posting_date",
+            "fieldtype": "Date",
+            "label": "Posting Date",
+            "width": 120,
+        },
+        {
+            "fieldname": "name",
+            "fieldtype": "Link",
+            "label": "Disbursement",
+            "options": "B2C Payment Disbursement",
+            "width": 150,
+        },
+        {
+            "fieldname": "company",
+            "fieldtype": "Link",
+            "label": "Company",
+            "options": "Company",
+            "width": 150,
+        },
+        {
+            "fieldname": "mode_of_payment",
+            "fieldtype": "Link",
+            "label": "Mode of Payment",
+            "options": "Mode of Payment",
+            "width": 150,
+        },
+        {
+            "fieldname": "transaction_to_pay_against",
+            "fieldtype": "Link",
+            "label": "Transaction to Pay Against",
+            "options": "DocType",
+            "width": 150,
+        },
+        {
+            "fieldname": "currency",
+            "fieldtype": "Link",
+            "label": "Currency",
+            "options": "Currency",
+            "width": 100,
+        },
+        {
+            "fieldname": "total_amount",
+            "fieldtype": "Currency",
+            "label": "Amount",
+            "width": 120,
+        },
+        {
+            "fieldname": "party",
+            "fieldtype": "Data",  # TODO: Change to Link if needed
+            "label": "Party",
+            "width": 150,
+        },
+        {
+			"fieldname": "party_type",
+			"fieldtype": "Data",  # TODO: Change to Link if needed
+			"label": "Party Type",
+			"width": 150,
+		}
+    ]

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -62,7 +62,7 @@ def get_columns():
         },
         {
             "fieldname": "party_type",
-            "fieldtype": "Link",  # TODO: Change to Link if needed
+            "fieldtype": "Link",
             "label": "Party Type",
             "options": "Party Type",
             "width": 100,
@@ -78,24 +78,27 @@ def get_columns():
 
 
 def get_data(filters):
-    query = """
-		SELECT
-			d.name,
-			d.payment_type,
-			d.posting_date,
-			d.company,
-			d.mode_of_payment,
-			d.transaction_to_pay_against,
-			r.total_amount,
-			r.currency,
-			r.party,
-			r.party_type
-		FROM
-			`tabB2C Payment Disbursement` d
-		LEFT JOIN
-			`tabB2C Payment Disbursement Reference` r
-		ON
-			d.name = r.parent
-	"""
-    data = frappe.db.sql(query, as_dict=True)
+    Disbursement = frappe.qb.DocType("B2C Payment Disbursement")
+    Reference = frappe.qb.DocType("B2C Payment Disbursement Reference")
+
+    query = (
+        frappe.qb.from_(Disbursement)
+        .left_join(Reference)
+        .on(Disbursement.name == Reference.parent)
+        .select(
+            Disbursement.name.as_("name"),
+            Disbursement.payment_type.as_("payment_type"),
+            Disbursement.posting_date.as_("posting_date"),
+            Disbursement.company.as_("company"),
+            Disbursement.mode_of_payment.as_("mode_of_payment"),
+            Disbursement.transaction_to_pay_against.as_("transaction_to_pay_against"),
+            Disbursement.status.as_("status"),
+            Reference.total_amount.as_("total_amount"),
+            Reference.currency.as_("currency"),
+            Reference.party.as_("party"),
+            Reference.party_type.as_("party_type"),
+        )
+    )
+
+    data = query.run(as_dict=True)
     return data

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2025, Navari Limited and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 
 
 def execute(filters=None):
     columns = get_columns()
-    columns = get_data(filters)
+    data = get_data(filters)
 
     return columns, data
 
@@ -24,14 +24,14 @@ def get_columns():
             "fieldtype": "Link",
             "label": "Disbursement",
             "options": "B2C Payment Disbursement",
-            "width": 150,
+            "width": 250,
         },
         {
             "fieldname": "company",
             "fieldtype": "Link",
             "label": "Company",
             "options": "Company",
-            "width": 150,
+            "width": 250,
         },
         {
             "fieldname": "mode_of_payment",
@@ -61,15 +61,41 @@ def get_columns():
             "width": 120,
         },
         {
+            "fieldname": "party_type",
+            "fieldtype": "Link",  # TODO: Change to Link if needed
+            "label": "Party Type",
+            "options": "Party Type",
+            "width": 100,
+        },
+        {
             "fieldname": "party",
             "fieldtype": "Data",  # TODO: Change to Link if needed
             "label": "Party",
             "width": 150,
         },
-        {
-			"fieldname": "party_type",
-			"fieldtype": "Data",  # TODO: Change to Link if needed
-			"label": "Party Type",
-			"width": 150,
-		}
+        {"fieldname": "status", "fieldtype": "Data", "label": "Status", "width": 100},
     ]
+
+
+def get_data(filters):
+    query = """
+		SELECT
+			d.name,
+			d.payment_type,
+			d.posting_date,
+			d.company,
+			d.mode_of_payment,
+			d.transaction_to_pay_against,
+			r.total_amount,
+			r.currency,
+			r.party,
+			r.party_type
+		FROM
+			`tabB2C Payment Disbursement` d
+		LEFT JOIN
+			`tabB2C Payment Disbursement Reference` r
+		ON
+			d.name = r.parent
+	"""
+    data = frappe.db.sql(query, as_dict=True)
+    return data

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -31,7 +31,7 @@ def get_columns():
             "fieldtype": "Link",
             "label": "Mode of Payment",
             "options": "Mode of Payment",
-            "width": 150,
+            "width": 250,
         },
         {
             "fieldname": "transaction_to_pay_against",
@@ -133,7 +133,11 @@ def get_data(filters):
         for ref in references:
             final_report_data.append(
                 {
-                    "posting_date": ref.posting_date if "posting_date" in ref else None,
+                    "posting_date": (
+                        ref.posting_date
+                        if "posting_date" in ref
+                        else disburse.posting_date
+                    ),
                     "name": disburse.name,
                     "company": disburse.company,
                     "mode_of_payment": disburse.mode_of_payment,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -129,15 +129,16 @@ def get_data(filters):
 
         references = references_query.run(as_dict=True)
 
+        if len(references) == 0:
+            # If no references, return nothing
+            final_report_data.pop()
+            return final_report_data
+
         current_disbursement_subtotal = 0.0
         for ref in references:
             final_report_data.append(
                 {
-                    "posting_date": (
-                        ref.posting_date
-                        if "posting_date" in ref
-                        else disburse.posting_date
-                    ),
+                    "posting_date": disburse.posting_date,
                     "name": disburse.name,
                     "company": disburse.company,
                     "mode_of_payment": disburse.mode_of_payment,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Navari Limited and contributors
+# For license information, please see license.txt
+
+# import frappe
+
+
+def execute(filters=None):
+	columns, data = [], []
+	return columns, data

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -25,6 +25,19 @@ def get_columns():
             "width": 250,
         },
         {
+            "fieldname": "party_type",
+            "fieldtype": "Link",
+            "label": "Party Type",
+            "options": "Party Type",
+            "width": 100,
+        },
+        {
+            "fieldname": "party",
+            "fieldtype": "Data",
+            "label": "Party",
+            "width": 150,
+        },
+        {
             "fieldname": "mode_of_payment",
             "fieldtype": "Link",
             "label": "Mode of Payment",
@@ -36,19 +49,6 @@ def get_columns():
             "fieldtype": "Link",
             "label": "Transaction to Pay Against",
             "options": "DocType",
-            "width": 150,
-        },
-        {
-            "fieldname": "party_type",
-            "fieldtype": "Link",
-            "label": "Party Type",
-            "options": "Party Type",
-            "width": 100,
-        },
-        {
-            "fieldname": "party",
-            "fieldtype": "Data",
-            "label": "Party",
             "width": 150,
         },
         {

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -100,5 +100,21 @@ def get_data(filters):
         )
     )
 
+    query = apply_filters(query, filters, Disbursement, Reference)
+
     data = query.run(as_dict=True)
+
     return data
+
+
+def apply_filters(query, filters, Disbursement, Reference):
+    if filters:
+        if filters.get("start_date"):
+            query = query.where(Disbursement.posting_date >= filters["start_date"])
+        if filters.get("end_date"):
+            query = query.where(Disbursement.posting_date <= filters["end_date"])
+        if filters.get("company"):
+            query = query.where(Disbursement.company == filters["company"])
+        if filters.get("party_type"):
+            query = query.where(Reference.party_type == filters["party_type"])
+    return query

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -1,7 +1,5 @@
-# Copyright (c) 2025, Navari Limited and contributors
-# For license information, please see license.txt
-
 import frappe
+from frappe.utils import flt
 
 
 def execute(filters=None):
@@ -71,31 +69,61 @@ def get_columns():
 
 
 def get_data(filters):
+    """Fetches data for the B2C Disbursement Summary report based on the provided filters."""
     Disbursement = frappe.qb.DocType("B2C Payment Disbursement")
     Reference = frappe.qb.DocType("B2C Payment Disbursement Reference")
 
     final_report_data = []
+    disbursement_names = []
 
-    disbursement_query = (
-        frappe.qb.from_(Disbursement)
-        .select(
-            Disbursement.name,
-            Disbursement.posting_date,
-            Disbursement.company,
-            Disbursement.mode_of_payment,
-            Disbursement.transaction_to_pay_against,
-            Disbursement.status,
-            Disbursement.payment_type,
-        )
-        .orderby(Disbursement.posting_date)
+    disbursement_query = frappe.qb.from_(Disbursement).select(
+        Disbursement.name,
+        Disbursement.posting_date,
+        Disbursement.company,
+        Disbursement.mode_of_payment,
+        Disbursement.transaction_to_pay_against,
+        Disbursement.status,
+        Disbursement.payment_type,
     )
 
     disbursement_query = apply_disbursement_filters(
         disbursement_query, filters, Disbursement
     )
-    disbursements = disbursement_query.run(as_dict=True)
+    disbursements_list = disbursement_query.run(as_dict=True)
 
-    for disburse in disbursements:
+    disbursements_map = {d.name: d for d in disbursements_list}
+    disbursement_names = list(disbursements_map.keys())
+
+    if not disbursement_names:
+        return []
+
+    references_query = (
+        frappe.qb.from_(Reference)
+        .select(
+            Reference.parent,
+            Reference.total_amount,
+            Reference.currency,
+            Reference.party,
+            Reference.party_type,
+        )
+        .where(Reference.parent.isin(disbursement_names))
+    )
+
+    if filters.get("party_type"):
+        references_query = references_query.where(
+            Reference.party_type == filters["party_type"]
+        )
+
+    all_references = references_query.run(as_dict=True)
+
+    grouped_references = {}
+    for ref in all_references:
+        grouped_references.setdefault(ref.parent, []).append(ref)
+
+    for disburse_name in sorted(disbursements_map.keys()):
+        disburse = disbursements_map[disburse_name]
+        current_disbursement_references = grouped_references.get(disburse.name, [])
+        current_disbursement_subtotal = 0.0
 
         final_report_data.append(
             {
@@ -108,69 +136,45 @@ def get_data(filters):
                 "currency": None,
                 "party_type": None,
                 "party": None,
+                "status": disburse.status,
             }
         )
 
-        references_query = (
-            frappe.qb.from_(Reference)
-            .select(
-                Reference.total_amount,
-                Reference.currency,
-                Reference.party,
-                Reference.party_type,
-            )
-            .where(Reference.parent == disburse.name)
-        )
-
-        if filters.get("party_type"):
-            references_query = references_query.where(
-                Reference.party_type == filters["party_type"]
-            )
-
-        references = references_query.run(as_dict=True)
-
-        if len(references) == 0:
-            # If no references, return nothing
-            final_report_data.pop()
-            return final_report_data
-
-        current_disbursement_subtotal = 0.0
-        for ref in references:
+        for ref in current_disbursement_references:
             final_report_data.append(
                 {
                     "posting_date": disburse.posting_date,
                     "name": disburse.name,
                     "company": disburse.company,
                     "mode_of_payment": disburse.mode_of_payment,
-                    "transaction_to_pay_against": (disburse.transaction_to_pay_against),
-                    "status": ref.status if "status" in ref else disburse.status,
-                    "total_amount": ref.total_amount,
+                    "transaction_to_pay_against": disburse.transaction_to_pay_against,
+                    "status": disburse.status,
+                    "total_amount": flt(ref.total_amount),
                     "currency": ref.currency,
                     "party_type": ref.party_type,
                     "party": ref.party,
                 }
             )
-            if ref.total_amount is not None:
-                current_disbursement_subtotal += float(ref.total_amount)
+            current_disbursement_subtotal += flt(ref.total_amount)
 
-        final_report_data.append(
-            {
-                "is_subtotal": True,
-                "posting_date": None,
-                "name": f"{disburse.name}",
-                "company": None,
-                "mode_of_payment": None,
-                "transaction_to_pay_against": None,
-                "currency": None,
-                "total_amount": current_disbursement_subtotal,
-                "party_type": None,
-                "party": None,
-                "status": None,
-                "bold": True,
-            }
-        )
-
-        final_report_data.append({})
+        if current_disbursement_references:
+            final_report_data.append(
+                {
+                    "is_subtotal": True,
+                    "posting_date": None,
+                    "name": f"{disburse.name}",
+                    "company": None,
+                    "mode_of_payment": None,
+                    "transaction_to_pay_against": None,
+                    "currency": None,
+                    "total_amount": current_disbursement_subtotal,
+                    "party_type": None,
+                    "party": None,
+                    "status": None,
+                    "bold": True,
+                }
+            )
+            final_report_data.append({})
 
     return final_report_data
 
@@ -184,5 +188,11 @@ def apply_disbursement_filters(query, filters, Disbursement):
             query = query.where(Disbursement.posting_date <= filters["end_date"])
         if filters.get("company"):
             query = query.where(Disbursement.company == filters["company"])
+        if filters.get("mode_of_payment"):
+            query = query.where(
+                Disbursement.mode_of_payment == filters["mode_of_payment"]
+            )
+        if filters.get("status"):
+            query = query.where(Disbursement.status == filters["status"])
 
     return query

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.py
@@ -27,13 +27,6 @@ def get_columns():
             "width": 250,
         },
         {
-            "fieldname": "company",
-            "fieldtype": "Link",
-            "label": "Company",
-            "options": "Company",
-            "width": 250,
-        },
-        {
             "fieldname": "mode_of_payment",
             "fieldtype": "Link",
             "label": "Mode of Payment",
@@ -45,6 +38,19 @@ def get_columns():
             "fieldtype": "Link",
             "label": "Transaction to Pay Against",
             "options": "DocType",
+            "width": 150,
+        },
+        {
+            "fieldname": "party_type",
+            "fieldtype": "Link",
+            "label": "Party Type",
+            "options": "Party Type",
+            "width": 100,
+        },
+        {
+            "fieldname": "party",
+            "fieldtype": "Data",
+            "label": "Party",
             "width": 150,
         },
         {
@@ -60,19 +66,6 @@ def get_columns():
             "label": "Amount",
             "width": 120,
         },
-        {
-            "fieldname": "party_type",
-            "fieldtype": "Link",
-            "label": "Party Type",
-            "options": "Party Type",
-            "width": 100,
-        },
-        {
-            "fieldname": "party",
-            "fieldtype": "Data",  # TODO: Change to Link if needed
-            "label": "Party",
-            "width": 150,
-        },
         {"fieldname": "status", "fieldtype": "Data", "label": "Status", "width": 100},
     ]
 
@@ -81,33 +74,104 @@ def get_data(filters):
     Disbursement = frappe.qb.DocType("B2C Payment Disbursement")
     Reference = frappe.qb.DocType("B2C Payment Disbursement Reference")
 
-    query = (
+    final_report_data = []
+
+    disbursement_query = (
         frappe.qb.from_(Disbursement)
-        .left_join(Reference)
-        .on(Disbursement.name == Reference.parent)
         .select(
-            Disbursement.name.as_("name"),
-            Disbursement.payment_type.as_("payment_type"),
-            Disbursement.posting_date.as_("posting_date"),
-            Disbursement.company.as_("company"),
-            Disbursement.mode_of_payment.as_("mode_of_payment"),
-            Disbursement.transaction_to_pay_against.as_("transaction_to_pay_against"),
-            Disbursement.status.as_("status"),
-            Reference.total_amount.as_("total_amount"),
-            Reference.currency.as_("currency"),
-            Reference.party.as_("party"),
-            Reference.party_type.as_("party_type"),
+            Disbursement.name,
+            Disbursement.posting_date,
+            Disbursement.company,
+            Disbursement.mode_of_payment,
+            Disbursement.transaction_to_pay_against,
+            Disbursement.status,
+            Disbursement.payment_type,
         )
+        .orderby(Disbursement.posting_date)
     )
 
-    query = apply_filters(query, filters, Disbursement, Reference)
+    disbursement_query = apply_disbursement_filters(
+        disbursement_query, filters, Disbursement
+    )
+    disbursements = disbursement_query.run(as_dict=True)
 
-    data = query.run(as_dict=True)
+    for disburse in disbursements:
 
-    return data
+        final_report_data.append(
+            {
+                "posting_date": disburse.posting_date,
+                "name": disburse.name,
+                "company": disburse.company,
+                "mode_of_payment": disburse.mode_of_payment,
+                "transaction_to_pay_against": disburse.transaction_to_pay_against,
+                "total_amount": None,
+                "currency": None,
+                "party_type": None,
+                "party": None,
+            }
+        )
+
+        references_query = (
+            frappe.qb.from_(Reference)
+            .select(
+                Reference.total_amount,
+                Reference.currency,
+                Reference.party,
+                Reference.party_type,
+            )
+            .where(Reference.parent == disburse.name)
+        )
+
+        if filters.get("party_type"):
+            references_query = references_query.where(
+                Reference.party_type == filters["party_type"]
+            )
+
+        references = references_query.run(as_dict=True)
+
+        current_disbursement_subtotal = 0.0
+        for ref in references:
+            final_report_data.append(
+                {
+                    "posting_date": ref.posting_date if "posting_date" in ref else None,
+                    "name": disburse.name,
+                    "company": disburse.company,
+                    "mode_of_payment": disburse.mode_of_payment,
+                    "transaction_to_pay_against": (disburse.transaction_to_pay_against),
+                    "status": ref.status if "status" in ref else disburse.status,
+                    "total_amount": ref.total_amount,
+                    "currency": ref.currency,
+                    "party_type": ref.party_type,
+                    "party": ref.party,
+                }
+            )
+            if ref.total_amount is not None:
+                current_disbursement_subtotal += float(ref.total_amount)
+
+        final_report_data.append(
+            {
+                "is_subtotal": True,
+                "posting_date": None,
+                "name": f"{disburse.name}",
+                "company": None,
+                "mode_of_payment": None,
+                "transaction_to_pay_against": None,
+                "currency": None,
+                "total_amount": current_disbursement_subtotal,
+                "party_type": None,
+                "party": None,
+                "status": None,
+                "bold": True,
+            }
+        )
+
+        final_report_data.append({})
+
+    return final_report_data
 
 
-def apply_filters(query, filters, Disbursement, Reference):
+def apply_disbursement_filters(query, filters, Disbursement):
+    """Applies filters relevant to the B2C Payment Disbursement doctype."""
     if filters:
         if filters.get("start_date"):
             query = query.where(Disbursement.posting_date >= filters["start_date"])
@@ -115,6 +179,5 @@ def apply_filters(query, filters, Disbursement, Reference):
             query = query.where(Disbursement.posting_date <= filters["end_date"])
         if filters.get("company"):
             query = query.where(Disbursement.company == filters["company"])
-        if filters.get("party_type"):
-            query = query.where(Reference.party_type == filters["party_type"])
+
     return query

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/stk_push_request_status/stk_push_request_status.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/stk_push_request_status/stk_push_request_status.py
@@ -103,19 +103,6 @@ def get_data(filters):
     MpesaExpressRequest = DocType("Mpesa Express Request")
     PaymentRequest = DocType("Payment Request")
 
-    # TODO: Delete this commented code once the query is confirmed to work.
-    # query = frappe.qb.from_(MpesaExpressRequest).select(
-    #     MpesaExpressRequest.name.as_("transaction_id"),
-    #     MpesaExpressRequest.amount,
-    #     MpesaExpressRequest.phone_number,
-    #     MpesaExpressRequest.status,
-    #     MpesaExpressRequest.timestamp,
-    #     MpesaExpressRequest.account_reference.as_("merchant_request_id"),
-    #     MpesaExpressRequest.name.as_("checkout_request_id"),
-    #     MpesaExpressRequest.checkout_request_id,
-    #     MpesaExpressRequest.result_desc.as_("error_message"),
-    # )
-
     query = (
         frappe.qb.from_(MpesaExpressRequest)
         .left_join(PaymentRequest)


### PR DESCRIPTION
This Pull Request introduces the "B2C Disbursement Summary" report, designed to provide a comprehensive overview of B2C Payment Disbursements and their associated references. The primary problem addressed by this report, and its subsequent optimization, is the need for an efficient way to view detailed disbursement information, including linked payment references efficiently.

It also implement issue [#23](https://github.com/navariltd/frappe-mpsa-payments/issues/28)

## Technical Implementation

1. `Optimized Database Queries`: Database queries are minimized by fetching all disbursements in one go, then all their related references in a second, single query using isin(), avoiding the N+1 problem.

2. `In-Memory Data Grouping`: Fetched references are grouped in Python memory by their parent disbursement, eliminating redundant database calls during report generation.

3. `Client-Side Formatting`: A custom formatter in report.js enhances readability by bolding subtotals and blanking irrelevant data points.

## Sample Screenshot

![image](https://github.com/user-attachments/assets/e5d44b31-cf1b-448d-a362-16a89cb15618)
