### PR TITLE
fix(sales_invoice): Refine stkpush logic for new sales invoices

### DIFF
--- a/frappe_mpsa_payments/public/js/sales_invoice.js
+++ b/frappe_mpsa_payments/public/js/sales_invoice.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on("Sales Invoice", {
   refresh(frm) {
-    if (frm.doc.is_pos || frm.doc.docstatus === 0) {
+    if (!frm.is_new() && frm.doc.is_pos && frm.doc.docstatus === 0) {
       if (frm.doc.outstanding_amount > 0) {
         frappe.call({
           method:
@@ -198,6 +198,9 @@ frappe.ui.form.on("Sales Invoice Payment", {
 });
 
 function setup_stk_push_button_logic(frm) {
+  if (frm.is_new()) {
+    return;
+  }
   const child_table = frm.doc.payments || [];
 
   child_table.forEach((row) => {


### PR DESCRIPTION
<p>This pull request improves the conditional logic in the <strong>Sales Invoice</strong> and <strong>Sales Invoice Payment</strong> forms to enhance user experience and prevent unintended behavior, particularly with regards to STK push functionality. These changes ensure that certain operations, such as button rendering and STK push setup, are only executed on existing records, avoiding unnecessary logic execution on new forms.</p>
<hr>
<h2>Key Enhancements</h2>
<h3>🧾 Sales Invoice (<code inline="">sales_invoice.js</code>)</h3>
<ul>
<li>
<p><strong>Improved Condition in <code inline="">refresh</code> Method</strong><br>
Updated the condition to check that the form is <strong>not new</strong> (<code inline="">!frm.is_new()</code>) before executing STK-related logic.</p>
<ul>
<li>
<p>Ensures the STK push button and logic only appear on existing draft POS invoices.</p>
</li>
<li>
<p>Prevents premature logic execution during invoice creation.</p>
</li>
</ul>
</li>
</ul>
<hr>
<h3>💳 Sales Invoice Payment (<code inline="">sales_invoice_payment.js</code>)</h3>
<ul>
<li>
<p><strong>Early Exit in <code inline="">setup_stk_push_button_logic</code></strong><br>
Introduced a guard clause to skip the button setup logic entirely for new documents (<code inline="">if (frm.is_new()) return;</code>).</p>
<ul>
<li>
<p>Avoids rendering the STK push button on unsaved payment entries.</p>
</li>
<li>
<p>Prevents errors and unintended side effects when initializing the form.</p>
</li>
</ul>
</li>
</ul>

