### PR TITLE
Prioritize Express Requests and queue C2B creation to prevent duplicates

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -407,6 +407,8 @@ def stk_push_callback(**kwargs) -> None:
             },
         )
 
+        request_doc.validate_duplicate_c2b_records()
+
         integration_req = frappe.get_doc(
             "Integration Request", {"output": ["like", f"%{checkout_request_id}%"]}
         )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -1,30 +1,33 @@
 from __future__ import unicode_literals
-import json
-import time
+
 import base64
 import datetime
+import json
 from typing import Any
 
+import frappe
 import requests
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import flt
 from requests.auth import HTTPBasicAuth
 
-import frappe
-from frappe import _
-from frappe.utils import flt
-from frappe.model.document import Document
-
-from .process_request import process_request
-from .mpesa_response_handler import stk_push_on_success, transaction_status_on_success, balance_query_on_success
-from ...utils.doctype_names import MPESA_SETTINGS_DOCTYPE, MPESA_EXPRESS_REQUEST_DOCTYPE
+from ...utils.doctype_names import MPESA_EXPRESS_REQUEST_DOCTYPE, MPESA_SETTINGS_DOCTYPE
 from ...utils.encoding_initiator_password import (
     generate_security_credential,
 )
 from ...utils.utils import (
     build_callback_url,
+    handle_successful_transaction,
     log_and_throw_error,
     update_mpesa_request_status,
-    handle_successful_transaction,
 )
+from .mpesa_response_handler import (
+    balance_query_on_success,
+    stk_push_on_success,
+    transaction_status_on_success,
+)
+from .process_request import process_request
 
 
 @frappe.whitelist(allow_guest=True)
@@ -34,38 +37,43 @@ def balance_query_callback(**kwargs) -> None:
     args = frappe._dict(kwargs)
     result_data = args.get("Result")
     if not result_data:
-        frappe.log_error("M-Pesa Balance Query Error", "Missing 'Result' in callback response")
+        frappe.log_error(
+            "M-Pesa Balance Query Error", "Missing 'Result' in callback response"
+        )
         return
 
     result_code = result_data.get("ResultCode")
     result_desc = result_data.get("ResultDesc", "No description provided")
 
     if result_code is None:
-        frappe.log_error("M-Pesa Balance Query Error", "Missing 'ResultCode' in callback response")
+        frappe.log_error(
+            "M-Pesa Balance Query Error", "Missing 'ResultCode' in callback response"
+        )
         return
 
     conversation_id = result_data.get("ConversationID")
     if not conversation_id:
-        frappe.log_error("M-Pesa Balance Query Error", "ConversationID missing in callback response")
+        frappe.log_error(
+            "M-Pesa Balance Query Error", "ConversationID missing in callback response"
+        )
         return
 
     integration_request = frappe.get_list(
         "Integration Request",
         filters=[["output", "like", f"%{conversation_id}%"]],
         fields=["name", "output", "reference_docname"],
-        ignore_permissions=True
+        ignore_permissions=True,
     )
 
     if not integration_request:
         frappe.log_error(
             "M-Pesa Balance Query Error",
-            f"No matching Integration Request found for ConversationID: {conversation_id}"
+            f"No matching Integration Request found for ConversationID: {conversation_id}",
         )
         return
 
     request_doc = frappe.get_doc("Integration Request", integration_request[0].name)
     request_doc.flags.ignore_permissions = True
-
 
     if str(result_code) != "0":
         request_doc.status = "Failed"
@@ -73,7 +81,7 @@ def balance_query_callback(**kwargs) -> None:
         request_doc.save(ignore_permissions=True)
         frappe.log_error(
             title="M-Pesa Balance Query Error",
-            message=f"ResultCode: {result_code}, ResultDesc: {result_desc}, Data: {json.dumps(result_data, indent=4)}"
+            message=f"ResultCode: {result_code}, ResultDesc: {result_desc}, Data: {json.dumps(result_data, indent=4)}",
         )
         return
 
@@ -89,12 +97,17 @@ def balance_query_callback(**kwargs) -> None:
             break
 
     if not account_balance:
-        frappe.log_error("M-Pesa Balance Query Error", "AccountBalance missing in callback response")
+        frappe.log_error(
+            "M-Pesa Balance Query Error", "AccountBalance missing in callback response"
+        )
         return
 
     settings_docname = integration_request[0].get("reference_docname")
     if not settings_docname:
-        frappe.log_error("M-Pesa Balance Query Error", "Reference document name missing in Integration Request")
+        frappe.log_error(
+            "M-Pesa Balance Query Error",
+            "Reference document name missing in Integration Request",
+        )
         return
 
     settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, settings_docname)
@@ -102,8 +115,9 @@ def balance_query_callback(**kwargs) -> None:
 
     update_account_balances(account_balance, settings)
 
-    frappe.publish_realtime(event="refresh_form", doctype=MPESA_SETTINGS_DOCTYPE, docname=settings_docname)
-
+    frappe.publish_realtime(
+        event="refresh_form", doctype=MPESA_SETTINGS_DOCTYPE, docname=settings_docname
+    )
 
 
 def update_account_balances(account_balance, settings):
@@ -119,52 +133,61 @@ def update_account_balances(account_balance, settings):
         "Loan Disbursement Account": "loan_disbursement_account",
         "Organization Settlement Account": "organization_settlement_account",
         "Advanced Deduction Account": "advanced_deduction_account",
-        "Savings Deduction Account": "savings_deduction_account"
+        "Savings Deduction Account": "savings_deduction_account",
     }
 
-    balances = account_balance.split("&") 
+    balances = account_balance.split("&")
     for balance in balances:
-        details = balance.split("|") 
+        details = balance.split("|")
         if len(details) >= 3:
             account_name = details[0]
             try:
-                available_balance = float(details[2]) 
+                available_balance = float(details[2])
             except ValueError:
-                available_balance = 0.0 
-                
+                available_balance = 0.0
+
             field_name = account_mapping.get(account_name)
             if field_name:
-                frappe.db.set_value(MPESA_SETTINGS_DOCTYPE, settings.name, field_name, available_balance)
+                frappe.db.set_value(
+                    MPESA_SETTINGS_DOCTYPE, settings.name, field_name, available_balance
+                )
 
     return {"status": "success", "message": "Account balances updated successfully"}
 
-    
+
 @frappe.whitelist()
 def get_account_balance(name: str) -> Any:
-    """Call account balance API to send the request to the Mpesa Servers."""        
+    """Call account balance API to send the request to the Mpesa Servers."""
     try:
         settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, name)
         certs = frappe.get_single("Mpesa Public Key Certificate")
         cert_url = ""
-        
+
         if settings.sandbox:
             cert_url = certs.sandbox_certificate
         else:
             cert_url = certs.production_certificate
-            
+
         security_credential = generate_security_credential(
-            settings.get_password("initiator_password", "") if settings.initiator_password else "",
-            cert_url
+            settings.get_password("initiator_password", "")
+            if settings.initiator_password
+            else "",
+            cert_url,
         )
 
         endpoint = "/mpesa/accountbalance/v1/query"
-        
-        callback_url = build_callback_url("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.balance_query_callback")
-        timeout_url = build_callback_url("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.handle_queue_timeout")
-                
+
+        callback_url = build_callback_url(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.balance_query_callback"
+        )
+        timeout_url = build_callback_url(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.handle_queue_timeout"
+        )
+
         payload = {
             "Initiator": settings.initiator_name,
-            "SecurityCredential": settings.get_password("security_credential") or security_credential, 
+            "SecurityCredential": settings.get_password("security_credential")
+            or security_credential,
             "CommandID": "AccountBalance",
             "PartyA": settings.business_shortcode,
             "IdentifierType": "4",
@@ -185,9 +208,11 @@ def get_account_balance(name: str) -> Any:
         )
         return response
 
-    except Exception as e:
+    except Exception:
         frappe.log_error(frappe.get_traceback(), "Mpesa Balance Query Error")
-        frappe.log_error(_("Failed to check mpesa balance. Please check the error logs."))
+        frappe.log_error(
+            _("Failed to check mpesa balance. Please check the error logs.")
+        )
 
 
 @frappe.whitelist()
@@ -220,25 +245,41 @@ def check_transaction_status(name: str) -> Any:
         )
         return response
 
-    except Exception as e:
+    except Exception:
         frappe.log_error(frappe.get_traceback(), "STK Push Query Error")
-        frappe.log_error(_("Failed to check transaction status. Please check the error logs."))
-        
-def generate_request_password(settings: Document, time: str ) -> str:
+        frappe.log_error(
+            _("Failed to check transaction status. Please check the error logs.")
+        )
+
+
+def generate_request_password(settings: Document, time: str) -> str:
     """Generate the password for making a request to the M-Pesa API."""
     return base64.b64encode(
         f"{settings.business_shortcode}{settings.get_password('online_passkey')}{time}".encode()
-        ).decode()
-    
-def transaction_status_error_callback(response: dict, payload: dict, document_name: str, **kwargs) -> None:
-    time.sleep(5)
-    frappe.enqueue(
-        "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.check_transaction_status",
-        name=document_name,
-        enqueue_after_commit=True,
-        timeout=300
+    ).decode()
+
+
+def transaction_status_error_callback(
+    response: dict, payload: dict, document_name: str, **kwargs
+) -> None:
+    """Mark transaction as failed immediately if query fails."""
+    frappe.log_error(
+        message=f"Transaction {document_name} query failed.\nResponse: {frappe.as_json(response)}",
+        title="Mpesa Transaction Status Query Error",
     )
-            
+
+    frappe.db.set_value(
+        MPESA_EXPRESS_REQUEST_DOCTYPE,
+        document_name,
+        {
+            "status": "Failed",
+            "result_desc": response.get("errorMessage")
+            if isinstance(response, dict)
+            else "Unknown error",
+        },
+    )
+
+
 @frappe.whitelist()
 def initiate_stk_push(**args) -> any:
     """Generate STK push by making an API call to the STK push API."""
@@ -259,14 +300,20 @@ def initiate_stk_push(**args) -> any:
     required_fields = ["payment_gateway", "phone_number", "request_amount"]
     missing_fields = [field for field in required_fields if not args.get(field)]
     if missing_fields:
-        frappe.log_error(_("Missing required fields: {0}").format(", ".join(missing_fields)))
+        frappe.log_error(
+            _("Missing required fields: {0}").format(", ".join(missing_fields))
+        )
 
     try:
-        callback_url =  build_callback_url("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.stk_push_callback")
-        mpesa_settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, args.payment_gateway[6:])
+        callback_url = build_callback_url(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.stk_push_callback"
+        )
+        mpesa_settings = frappe.get_doc(
+            MPESA_SETTINGS_DOCTYPE, args.payment_gateway[6:]
+        )
         mobile_number = sanitize_mobile_number(args.phone_number or args.sender)
         amount = args.request_amount
-        business_shortcode =  mpesa_settings.business_shortcode
+        business_shortcode = mpesa_settings.business_shortcode
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
         reference_name = args.get("reference_name", "Online Payment")
 
@@ -276,7 +323,8 @@ def initiate_stk_push(**args) -> any:
             "Timestamp": timestamp,
             "Amount": amount,
             "PartyA": int(mobile_number),
-            "PartyB": business_shortcode if mpesa_settings.paybill_type == "Pay Bill"
+            "PartyB": business_shortcode
+            if mpesa_settings.paybill_type == "Pay Bill"
             else mpesa_settings.till_number,
             "PhoneNumber": int(mobile_number),
             "CallBackURL": callback_url,
@@ -288,7 +336,7 @@ def initiate_stk_push(**args) -> any:
         }
 
         endpoint = "/mpesa/stkpush/v1/processrequest"
-        
+
         response = process_request(
             endpoint=endpoint,
             method="POST",
@@ -301,11 +349,11 @@ def initiate_stk_push(**args) -> any:
         )
         return response
 
-    except Exception as e:
+    except Exception:
         frappe.log_error(frappe.get_traceback(), "STK Push Generation Error")
         frappe.log_error(_("Failed to generate STK push. Please check the error logs."))
 
-        
+
 @frappe.whitelist(allow_guest=True)
 def stk_push_callback(**kwargs) -> None:
     frappe.set_user("Administrator")
@@ -319,61 +367,75 @@ def stk_push_callback(**kwargs) -> None:
         result_code = transaction_response.get("ResultCode")
         status = "Completed" if str(result_code) == "0" else "Failed"
 
-        callback_metadata = transaction_response.get("CallbackMetadata", {}).get("Item", [])
+        callback_metadata = transaction_response.get("CallbackMetadata", {}).get(
+            "Item", []
+        )
         metadata_dict = {
-            item.get("Name"): item.get("Value") for item in callback_metadata if "Value" in item
+            item.get("Name"): item.get("Value")
+            for item in callback_metadata
+            if "Value" in item
         }
 
         transaction_date = metadata_dict.get("TransactionDate")
         if transaction_date:
             if not isinstance(transaction_date, str):
                 transaction_date = str(transaction_date)
-                
+
             date_obj = datetime.datetime.strptime(transaction_date, "%Y%m%d%H%M%S")
-            
+
             metadata_dict["TransactionDate"] = date_obj
 
-        request_doc = frappe.get_doc(MPESA_EXPRESS_REQUEST_DOCTYPE, {
-            "checkout_request_id": checkout_request_id
-        })
+        request_doc = frappe.get_doc(
+            MPESA_EXPRESS_REQUEST_DOCTYPE, {"checkout_request_id": checkout_request_id}
+        )
         settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, request_doc.settings)
 
         if status == "Completed" and request_doc.status != "Completed":
-            handle_successful_transaction(request_doc, metadata_dict, settings, checkout_request_id)
+            handle_successful_transaction(
+                request_doc, metadata_dict, settings, checkout_request_id
+            )
 
-        update_mpesa_request_status(request_doc.name, {
-            "result_code": result_code,
-            "result_desc": transaction_response.get("ResultDesc"),
-            "transaction_id": metadata_dict.get("MpesaReceiptNumber"),
-            "transaction_date": metadata_dict.get("TransactionDate"),
-            "status": status,
-        })
-        
-        integration_req = frappe.get_doc("Integration Request", {
-            "output": ["like", f"%{checkout_request_id}%"]
-        })
+        update_mpesa_request_status(
+            request_doc.name,
+            {
+                "result_code": result_code,
+                "result_desc": transaction_response.get("ResultDesc"),
+                "transaction_id": metadata_dict.get("MpesaReceiptNumber"),
+                "transaction_date": metadata_dict.get("TransactionDate"),
+                "status": status,
+            },
+        )
+
+        integration_req = frappe.get_doc(
+            "Integration Request", {"output": ["like", f"%{checkout_request_id}%"]}
+        )
         integration_req.flags.ignore_permissions = True
         current_output = integration_req.output or "{}"
-        output = json.dumps({
-            "stkpush_response": current_output,
-            "callback_result": transaction_response
-        }, indent=4)
-        
-        frappe.db.set_value("Integration Request", integration_req.name, {
-            "status": status,
-            "output": output,
-        })
+        output = json.dumps(
+            {
+                "stkpush_response": current_output,
+                "callback_result": transaction_response,
+            },
+            indent=4,
+        )
+
+        frappe.db.set_value(
+            "Integration Request",
+            integration_req.name,
+            {
+                "status": status,
+                "output": output,
+            },
+        )
 
     except Exception:
         log_and_throw_error("STK Push Callback Error", checkout_request_id)
 
-        
-        
+
 def sanitize_mobile_number(number: str) -> str:
     """Strip all non-digit characters, take the last 9 digits, and add country code."""
-    sanitized_number = ''.join(filter(str.isdigit, number))[-9:]
+    sanitized_number = "".join(filter(str.isdigit, number))[-9:]
     return "254" + sanitized_number
-
 
 
 def get_token(app_key, app_secret, base_url):
@@ -437,6 +499,7 @@ def get_mpesa_mode_of_payment(company):
             modes_of_payment.append(mode.mode_of_payment)
     return modes_of_payment
 
+
 @frappe.whitelist(allow_guest=True)
 def get_mpesa_draft_c2b_payments(
     company,
@@ -457,7 +520,7 @@ def get_mpesa_draft_c2b_payments(
     ]
 
     filters = {"company": company, "docstatus": 0}
-    order_by="posting_date desc, posting_time desc"
+    order_by = "posting_date desc, posting_time desc"
 
     if mode_of_payment:
         filters["mode_of_payment"] = mode_of_payment
@@ -473,21 +536,26 @@ def get_mpesa_draft_c2b_payments(
         filters["posting_date"] = ["<=", to_date]
 
     payments = frappe.get_all(
-        "Mpesa C2B Payment Register", 
-        filters=filters, fields=fields,order_by=order_by
+        "Mpesa C2B Payment Register", filters=filters, fields=fields, order_by=order_by
     )
-    
+
     return payments
-    
+
+
 @frappe.whitelist(allow_guest=True)
 def get_draft_pos_invoice(search_term=None):
-    from frappe.query_builder import DocType
-    from frappe.query_builder.functions import Concat
     from frappe import qb
+    from frappe.query_builder import DocType
 
     SalesInvoice = DocType("Sales Invoice")
     fields = ["*"]
-    status_filters = ["Overdue", "Partially Paid", "Unpaid", "Overdue and Discounted", "Partially Paid and Discounted"]
+    status_filters = [
+        "Overdue",
+        "Partially Paid",
+        "Unpaid",
+        "Overdue and Discounted",
+        "Partially Paid and Discounted",
+    ]
 
     # Create the base query
     query = (
@@ -499,15 +567,15 @@ def get_draft_pos_invoice(search_term=None):
     )
 
     if search_term:
-        search_filter = (
-            (SalesInvoice.customer.like(f"%{search_term}%")) |
-            (SalesInvoice.name.like(f"%{search_term}%"))
+        search_filter = (SalesInvoice.customer.like(f"%{search_term}%")) | (
+            SalesInvoice.name.like(f"%{search_term}%")
         )
         query = query.where(search_filter)
 
     invoices = query.run(as_dict=True)
 
-    frappe.response['message'] = invoices
+    frappe.response["message"] = invoices
+
 
 @frappe.whitelist()
 def submit_mpesa_payment(mpesa_payment, customer):
@@ -517,6 +585,7 @@ def submit_mpesa_payment(mpesa_payment, customer):
     except Exception as e:
         frappe.log_error(f"Error: {str(e)}", "submit_mpesa_payment")
         raise
+
 
 @frappe.whitelist()
 def submit_instant_mpesa_payment():
@@ -529,23 +598,25 @@ def submit_instant_mpesa_payment():
         frappe.log_error(f"Error: {str(e)}", "submit_instant_mpesa_payment")
         raise
 
+
 def process_mpesa_payment(mpesa_payment, customer, submit_payment=False):
     try:
         doc = frappe.get_doc("Mpesa C2B Payment Register", mpesa_payment)
         doc.customer = customer
-        #TODO: after testing, mode of payment
+        # TODO: after testing, mode of payment
         doc.mode_of_payment = get_mode_of_payment(doc)
-        doc.submit_payment=submit_payment
+        doc.submit_payment = submit_payment
         doc.save()
         doc.submit()
-        frappe.db.commit()  
+        frappe.db.commit()
 
-        doc.reload()  
+        doc.reload()
 
         return doc
     except Exception as e:
         frappe.log_error(f"Error: {str(e)}", "process_mpesa_payment")
         raise
+
 
 def get_payment_method(pos_profile):
     pos_profile_doc = frappe.get_doc("POS Profile", pos_profile)
@@ -554,13 +625,23 @@ def get_payment_method(pos_profile):
             return payment.mode_of_payment
     return None
 
+
 def get_mode_of_payment(mpesa_doc):
-    business_short_code=mpesa_doc.businessshortcode
-    mode_of_payment = frappe.get_value("Mpesa C2B Payment Register URL", {"business_shortcode": business_short_code, "register_status": "Success"}, "mode_of_payment")
+    business_short_code = mpesa_doc.businessshortcode
+    mode_of_payment = frappe.get_value(
+        "Mpesa C2B Payment Register URL",
+        {"business_shortcode": business_short_code, "register_status": "Success"},
+        "mode_of_payment",
+    )
     if mode_of_payment is None:
-        mode_of_payment = frappe.get_value("Mpesa C2B Payment Register URL", {"till_number": business_short_code, "register_status": "Success"}, "mode_of_payment")
+        mode_of_payment = frappe.get_value(
+            "Mpesa C2B Payment Register URL",
+            {"till_number": business_short_code, "register_status": "Success"},
+            "mode_of_payment",
+        )
     return mode_of_payment
-    
+
+
 @frappe.whitelist(allow_guest=True)
 def handle_transaction_status_result():
     """Handle the transaction status response from Mpesa"""
@@ -568,16 +649,18 @@ def handle_transaction_status_result():
         response = frappe.request.data
         response_data = json.loads(response)
 
-        integration_request = frappe.get_doc({
-            "doctype": "Integration Request",
-            "is_remote_request": 1,
-            "integration_request_service": "Mpesa Transaction Status Result Callback",
-            "reference_doctype": "Mpesa C2B Payment Register",
-            "status": "Queued",
-            "data": json.dumps(response_data),
-            "url": frappe.request.url,
-            "method": "POST"
-        }).insert(ignore_permissions=True)
+        integration_request = frappe.get_doc(
+            {
+                "doctype": "Integration Request",
+                "is_remote_request": 1,
+                "integration_request_service": "Mpesa Transaction Status Result Callback",
+                "reference_doctype": "Mpesa C2B Payment Register",
+                "status": "Queued",
+                "data": json.dumps(response_data),
+                "url": frappe.request.url,
+                "method": "POST",
+            }
+        ).insert(ignore_permissions=True)
         frappe.db.commit()
 
         frappe.enqueue(
@@ -586,50 +669,62 @@ def handle_transaction_status_result():
             timeout=300,
             job_id=f"mpesa_process_{integration_request.name}",
             integration_request_name=integration_request.name,
-            deduplicate=True
+            deduplicate=True,
         )
 
         return {"status": "queued", "message": "Transaction queued for processing"}
-    
+
     except json.JSONDecodeError as e:
-        frappe.log_error(f"Failed to decode JSON from Mpesa response: {str(e)}", "Mpesa API Error")
+        frappe.log_error(
+            f"Failed to decode JSON from Mpesa response: {str(e)}", "Mpesa API Error"
+        )
         return {"status": "error", "message": "Invalid JSON data"}
     except Exception as e:
         frappe.log_error(f"Error in Mpesa webhook: {str(e)}", "Mpesa API Error")
         return {"status": "error", "message": f"Webhook error: {str(e)}"}
-         
+
 
 def process_mpesa_integration_request(integration_request_name):
     """Process the Mpesa Integration Request and publish updates in real-time"""
     try:
         # Fetch the Integration Request
-        integration_request = frappe.get_doc("Integration Request", integration_request_name)
-        
+        integration_request = frappe.get_doc(
+            "Integration Request", integration_request_name
+        )
+
         # Parse the stored data
         response_data = json.loads(integration_request.data)
         result_data = response_data.get("Result", {})
-        result_parameters = result_data.get("ResultParameters", {}).get("ResultParameter", [])
-        result_params = {param.get("Key", ""): param.get("Value", "") for param in result_parameters if "Key" in param}
-        
+        result_parameters = result_data.get("ResultParameters", {}).get(
+            "ResultParameter", []
+        )
+        result_params = {
+            param.get("Key", ""): param.get("Value", "")
+            for param in result_parameters
+            if "Key" in param
+        }
+
         result_code = result_data.get("ResultCode", None)
         receipt_no = result_params.get("ReceiptNo", "")
         business_shortcode = result_params.get("CreditPartyName", "").split("-")
 
         if result_code == 0:
             if frappe.db.exists("Mpesa C2B Payment Register", {"transid": receipt_no}):
-                error_msg = f"Duplicate transaction: Receipt No {receipt_no} already exists"
+                error_msg = (
+                    f"Duplicate transaction: Receipt No {receipt_no} already exists"
+                )
                 integration_request.status = "Failed"
                 integration_request.output = error_msg
                 integration_request.save(ignore_permissions=True)
                 frappe.db.commit()
-                
+
                 frappe.publish_realtime(
                     event="mpesa_transaction_status",
                     message={"status": "error", "message": error_msg},
-                    user=frappe.session.user
+                    user=frappe.session.user,
                 )
                 return
-            
+
             # Create the Mpesa document
             mpesa_doc = frappe.new_doc("Mpesa C2B Payment Register")
             mpesa_doc.full_name = result_params.get("DebitPartyName", "")
@@ -641,11 +736,15 @@ def process_mpesa_integration_request(integration_request_name):
             mpesa_doc.billrefnumber = result_params.get("ReceiptNo", "")
             mpesa_doc.invoicenumber = result_params.get("TransactionID", "")
             mpesa_doc.orgaccountbalance = result_params.get("DebitAccountType", "")
-            mpesa_doc.thirdpartytransid = result_params.get("OriginatorConversationID", "")
+            mpesa_doc.thirdpartytransid = result_params.get(
+                "OriginatorConversationID", ""
+            )
 
             debit_party = result_params.get("DebitPartyName", "").split(" - ")
             mpesa_doc.msisdn = debit_party[0] if len(debit_party) > 0 else ""
-            name_parts = debit_party[1].split(" ") if len(debit_party) > 1 else ["", "", ""]
+            name_parts = (
+                debit_party[1].split(" ") if len(debit_party) > 1 else ["", "", ""]
+            )
             mpesa_doc.firstname = name_parts[0]
             mpesa_doc.middlename = name_parts[1] if len(name_parts) > 1 else ""
             mpesa_doc.lastname = name_parts[-1] if len(name_parts) > 2 else ""
@@ -662,10 +761,14 @@ def process_mpesa_integration_request(integration_request_name):
 
             frappe.publish_realtime(
                 event="mpesa_transaction_status",
-                message={"status": "success", "message": success_msg, "doc_name": mpesa_doc.name},
-                user=frappe.session.user
+                message={
+                    "status": "success",
+                    "message": success_msg,
+                    "doc_name": mpesa_doc.name,
+                },
+                user=frappe.session.user,
             )
-        
+
         else:
             error_msg = "Transaction failed with non-zero result code"
             integration_request.status = "Failed"
@@ -676,7 +779,7 @@ def process_mpesa_integration_request(integration_request_name):
             frappe.publish_realtime(
                 event="mpesa_transaction_status",
                 message={"status": "error", "message": error_msg},
-                user=frappe.session.user
+                user=frappe.session.user,
             )
 
     except Exception as e:
@@ -686,11 +789,14 @@ def process_mpesa_integration_request(integration_request_name):
         integration_request.save(ignore_permissions=True)
         frappe.db.commit()
 
-        frappe.log_error(f"{error_message}\nData: {integration_request.data}", "Mpesa Integration Error")
+        frappe.log_error(
+            f"{error_message}\nData: {integration_request.data}",
+            "Mpesa Integration Error",
+        )
         frappe.publish_realtime(
             event="mpesa_transaction_status",
             message={"status": "error", "message": error_message},
-            user=frappe.session.user
+            user=frappe.session.user,
         )
 
 
@@ -703,7 +809,7 @@ def handle_queue_timeout():
 
         frappe.log_error(
             title="Mpesa Queue Timeout",
-            message=f"Timeout response received: {frappe.as_json(response_data)}"
+            message=f"Timeout response received: {frappe.as_json(response_data)}",
         )
 
         return {"status": "timeout", "message": "Timeout response logged successfully."}
@@ -711,27 +817,24 @@ def handle_queue_timeout():
     except json.JSONDecodeError:
         frappe.log_error(
             title="Mpesa Timeout Error",
-            message="Failed to decode JSON from timeout response."
+            message="Failed to decode JSON from timeout response.",
         )
         return {"status": "error", "message": "Invalid JSON received."}
 
     except Exception as e:
         error_message = f"Mpesa Timeout Error: {str(e)}"
-        frappe.log_error(
-            title="Mpesa Timeout Error",
-            message=error_message
-        )
+        frappe.log_error(title="Mpesa Timeout Error", message=error_message)
         return {"status": "error", "message": str(e)}
+
 
 @frappe.whitelist(allow_guest=True)
 def verify_transaction(**kwargs) -> None:
     """Verify the transaction result received via callback from stk."""
     from ..doctype.mpesa_settings.mpesa_settings import (
-        get_completed_integration_requests_info,
         fetch_param_value,
-        
+        get_completed_integration_requests_info,
     )
-    
+
     transaction_response = frappe._dict(kwargs["Body"]["stkCallback"])
 
     checkout_id = getattr(transaction_response, "CheckoutRequestID", "")
@@ -740,7 +843,7 @@ def verify_transaction(**kwargs) -> None:
 
     integration_request = frappe.get_doc("Integration Request", checkout_id)
     transaction_data = frappe._dict(json.loads(integration_request.data))
-    total_paid = 0  
+    total_paid = 0
     success = False  # for reporting successfull callback to point of sale ui
 
     if transaction_response["ResultCode"] == 0:
@@ -803,6 +906,3 @@ def verify_transaction(**kwargs) -> None:
             ),
         },
     )
-
-
-

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -223,11 +223,11 @@ def check_transaction_status(name: str) -> Any:
         settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, express_request.settings)
 
         endpoint = "/mpesa/stkpushquery/v1/query"
-        time = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+        timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
         payload = {
             "BusinessShortCode": settings.business_shortcode,
-            "Password": generate_request_password(settings, time),
-            "Timestamp": time,
+            "Password": generate_request_password(settings, timestamp),
+            "Timestamp": timestamp,
             "CheckoutRequestID": express_request.checkout_request_id,
         }
 
@@ -252,11 +252,12 @@ def check_transaction_status(name: str) -> Any:
         )
 
 
-def generate_request_password(settings: Document, time: str) -> str:
+def generate_request_password(settings: Document, timestamp: str) -> str:
     """Generate the password for making a request to the M-Pesa API."""
-    return base64.b64encode(
-        f"{settings.business_shortcode}{settings.get_password('online_passkey')}{time}".encode()
-    ).decode()
+    shortcode = str(settings.business_shortcode).strip()
+    passkey = str(settings.get_password("online_passkey")).strip()
+    data_to_encode = f"{shortcode}{passkey}{timestamp}"
+    return base64.b64encode(data_to_encode.encode("utf-8")).decode("utf-8")
 
 
 def transaction_status_error_callback(

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import base64
 import datetime
 import json
+import time
 from typing import Any
 
 import frappe
@@ -457,21 +458,28 @@ def confirmation(**kwargs):
 
         frappe.set_user("Administrator")
 
-        doc = frappe.new_doc("Mpesa C2B Payment Register")
-        doc.transactiontype = args.get("TransactionType")
-        doc.transid = args.get("TransID")
-        doc.transtime = args.get("TransTime")
-        doc.transamount = flt(args.get("TransAmount"))
-        doc.businessshortcode = args.get("BusinessShortCode")
-        doc.billrefnumber = args.get("BillRefNumber")
-        doc.invoicenumber = args.get("InvoiceNumber")
-        doc.orgaccountbalance = args.get("OrgAccountBalance")
-        doc.thirdpartytransid = args.get("ThirdPartyTransID")
-        doc.msisdn = args.get("MSISDN")
-        doc.firstname = args.get("FirstName")
-        doc.middlename = args.get("MiddleName")
-        doc.lastname = args.get("LastName")
-        doc.insert(ignore_permissions=True)
+        frappe.enqueue(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.delayed_insert_c2b",
+            queue="short",
+            timeout=300,
+            is_async=True,
+            c2b_data={
+                "transactiontype": args.get("TransactionType"),
+                "transid": args.get("TransID"),
+                "transtime": args.get("TransTime"),
+                "transamount": flt(args.get("TransAmount")),
+                "businessshortcode": args.get("BusinessShortCode"),
+                "billrefnumber": args.get("BillRefNumber"),
+                "invoicenumber": args.get("InvoiceNumber"),
+                "orgaccountbalance": args.get("OrgAccountBalance"),
+                "thirdpartytransid": args.get("ThirdPartyTransID"),
+                "msisdn": args.get("MSISDN"),
+                "firstname": args.get("FirstName"),
+                "middlename": args.get("MiddleName"),
+                "lastname": args.get("LastName"),
+            },
+        )
+
         frappe.db.commit()
         context = {"ResultCode": 0, "ResultDesc": "Accepted"}
         return dict(context)
@@ -487,6 +495,37 @@ def confirmation(**kwargs):
 def validation(**kwargs):
     context = {"ResultCode": 0, "ResultDesc": "Accepted"}
     return dict(context)
+
+
+def delayed_insert_c2b(c2b_data: dict) -> None:
+    """
+    Insert C2B Payment Register after a small delay.
+    This ensures that any Express Request with the same transaction_id
+    is already created and can be prioritized.
+    """
+    try:
+        time.sleep(1)
+
+        if c2b_data.get("transid"):
+            express_exists = frappe.db.exists(
+                "Mpesa Express Request", {"transaction_id": c2b_data["transid"]}
+            )
+            if express_exists:
+                frappe.log_error(
+                    f"C2B {c2b_data['transid']} blocked due to existing Express Request",
+                    "C2B Insert Skipped",
+                )
+                return
+
+        doc = frappe.new_doc("Mpesa C2B Payment Register")
+        for k, v in c2b_data.items():
+            setattr(doc, k, v)
+
+        doc.insert(ignore_permissions=True)
+        frappe.db.commit()
+
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "Delayed C2B Insert Error")
 
 
 @frappe.whitelist()

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register.py
@@ -4,233 +4,305 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe_mpsa_payments.frappe_mpsa_payments.api.payment_entry import create_payment_entry, get_outstanding_invoices, get_unallocated_payments, create_and_reconcile_payment_reconciliation
+
+from frappe_mpsa_payments.frappe_mpsa_payments.api.payment_entry import (
+    create_and_reconcile_payment_reconciliation,
+    create_payment_entry,
+    get_outstanding_invoices,
+)
+
 
 class MpesaC2BPaymentRegister(Document):
-	def before_insert(self):
-		if self.thirdpartytransid:
-			er = frappe.db.get_value(
-				"Mpesa Express Request",
-				{ "merchant_request_id": self.thirdpartytransid },
-				["name", "status"],
-				as_dict=True
-			)
-			if er:
-				frappe.log_error(
-					message=f"Blocked C2B because matching Express Request {er.name} "
-							f"already exists (status={er.status})",
-					title="Mpesa C2B Insert Blocked"
-				)
-				frappe.throw(
-					_("Cannot record C2B payment: Express Request {0} already exists").format(er.name)
-				)
+    def before_insert(self):
+        if self.thirdpartytransid:
+            er = frappe.db.get_value(
+                "Mpesa Express Request",
+                {"merchant_request_id": self.thirdpartytransid},
+                ["name", "status"],
+                as_dict=True,
+            )
+            if er:
+                frappe.log_error(
+                    message=f"Blocked C2B because matching Express Request {er.name} "
+                    f"already exists (status={er.status})",
+                    title="Mpesa C2B Insert Blocked",
+                )
+                frappe.throw(
+                    _(
+                        "Cannot record C2B payment: Express Request {0} already exists"
+                    ).format(er.name)
+                )
 
-		self.set_missing_values()
+        if self.transid:
+            er2 = frappe.db.get_value(
+                "Mpesa Express Request",
+                {"transaction_id": self.transid},
+                ["name", "status"],
+                as_dict=True,
+            )
+            if er2:
+                frappe.log_error(
+                    message=f"Duplicate C2B payment detected: {self.transid} "
+                    f"already exists in Express Request {er2.name}",
+                    title="Mpesa C2B Duplicate",
+                )
+                frappe.throw(
+                    _(
+                        "Cannot record C2B payment: Transaction already captured in Express Request {0}"
+                    ).format(er2.name)
+                )
 
-	def after_insert(self):
-		try:
-			auto_reconcile = frappe.db.get_value(
-				"Mpesa Settings",
-				{"business_shortcode": self.businessshortcode},
-				"auto_reconcile_c2b",
-			)
+        self.set_missing_values()
 
-			if not auto_reconcile:
-				return
-			
-			self.db_set("submit_payment", 1)
-			self.submit()
-		
-		except Exception as e:
-			frappe.log_error(frappe.get_traceback(), f"C2B Auto-submit Error: {str(e)}")
+    def after_insert(self):
+        try:
+            auto_reconcile = frappe.db.get_value(
+                "Mpesa Settings",
+                {"business_shortcode": self.businessshortcode},
+                "auto_reconcile_c2b",
+            )
 
-	def set_missing_values(self):
-		self.currency = "KES"
-		self.full_name = self.full_name = " ".join(filter(None, [self.firstname, self.middlename, self.lastname]))
+            if not auto_reconcile:
+                return
 
-		register_url_list = frappe.get_all(
-			"Mpesa C2B Payment Register URL",
-			filters={
-				"business_shortcode": self.businessshortcode,
-				"register_status": "Success",
-			},
-			fields=["company", "mode_of_payment"],
-		)
-		if len(register_url_list) > 0:
-			self.company = register_url_list[0].company
-			self.mode_of_payment = register_url_list[0].mode_of_payment
+            self.db_set("submit_payment", 1)
+            self.submit()
 
-		if self.billrefnumber and not self.customer:
-			self._find_customer_from_billref(self.billrefnumber)        
+        except Exception as e:
+            frappe.log_error(frappe.get_traceback(), f"C2B Auto-submit Error: {str(e)}")
 
-	def before_submit(self):
-		if not self.transamount:
-			frappe.throw(_("Trans Amount is required"))
-		if not self.company:
-			frappe.throw(_("Company is required"))
-		if not self.customer:
-			frappe.throw(_("Customer is required"))
-		if not self.mode_of_payment:
-			frappe.throw(_("Mode of Payment is required"))
-			
+    def set_missing_values(self):
+        self.currency = "KES"
+        self.full_name = self.full_name = " ".join(
+            filter(None, [self.firstname, self.middlename, self.lastname])
+        )
 
-		if self.submit_payment:
-			
-			refs = []
-			invoice, order = self._get_matching_refs()
+        register_url_list = frappe.get_all(
+            "Mpesa C2B Payment Register URL",
+            filters={
+                "business_shortcode": self.businessshortcode,
+                "register_status": "Success",
+            },
+            fields=["company", "mode_of_payment"],
+        )
+        if len(register_url_list) > 0:
+            self.company = register_url_list[0].company
+            self.mode_of_payment = register_url_list[0].mode_of_payment
 
-			if invoice:
-				refs.append({"reference_doctype": "Sales Invoice", "reference_name": invoice, "allocated_amount": self.transamount})
-			
-			elif order:
-				refs.append({"reference_doctype": "Sales Order", "reference_name": order, "allocated_amount": self.transamount})
+        if self.billrefnumber and not self.customer:
+            self._find_customer_from_billref(self.billrefnumber)
 
-			payment_entry = create_payment_entry(
-				self.company,
-				self.customer,
-				self.transamount,
-				self.currency,
-				self.mode_of_payment,
-				"Customer",
-				self.posting_date,
-				self.name,
-				self.posting_date,
-				None,
-				self.submit_payment,
-				references=refs or None
-			)
+    def before_submit(self):
+        if not self.transamount:
+            frappe.throw(_("Trans Amount is required"))
+        if not self.company:
+            frappe.throw(_("Company is required"))
+        if not self.customer:
+            frappe.throw(_("Customer is required"))
+        if not self.mode_of_payment:
+            frappe.throw(_("Mode of Payment is required"))
 
-			self.payment_entry = payment_entry.name
-			   
-	def on_submit(self):
+        if self.submit_payment:
+            refs = []
+            invoice, order = self._get_matching_refs()
 
-		try:
-			self._reconcile_payment()
+            if invoice:
+                refs.append(
+                    {
+                        "reference_doctype": "Sales Invoice",
+                        "reference_name": invoice,
+                        "allocated_amount": self.transamount,
+                    }
+                )
 
-		except Exception as e:
-			frappe.log_error(frappe.get_traceback(), f"C2B Reconciliation Error: {str(e)}")
+            elif order:
+                refs.append(
+                    {
+                        "reference_doctype": "Sales Order",
+                        "reference_name": order,
+                        "allocated_amount": self.transamount,
+                    }
+                )
 
-	def _find_customer_from_billref(self, billrefnumber: str) -> str | None:
+            payment_entry = create_payment_entry(
+                self.company,
+                self.customer,
+                self.transamount,
+                self.currency,
+                self.mode_of_payment,
+                "Customer",
+                self.posting_date,
+                self.name,
+                self.posting_date,
+                None,
+                self.submit_payment,
+                references=refs or None,
+            )
 
-		if not billrefnumber:
-			return
+            self.payment_entry = payment_entry.name
 
-		sources = [
-			("Sales Invoice", "customer", {"docstatus": 1}),
-			("Sales Order", "customer", {"docstatus": 1}),
-			("Quotation", "party_name", {"docstatus": 1, "quotation_to": "Customer"}),
-			("Customer", "name", {})
-		]
+    def on_submit(self):
+        if self.transid:
+            exists = frappe.db.exists(
+                "Mpesa Express Request", {"transaction_id": self.transid}
+            )
+            if exists:
+                frappe.db.savepoint("before_c2b_submit")
+                try:
+                    self.cancel()
+                    frappe.throw(
+                        _(
+                            "Duplicate C2B transaction {0}. Cancelled automatically."
+                        ).format(self.transid)
+                    )
+                except Exception:
+                    frappe.db.rollback(save_point="before_c2b_submit")
+                    raise
 
-		for doctype, customer_field, extra_filters in sources:
-			filters = {"name": billrefnumber}
-			filters.update(extra_filters)
+        try:
+            self._reconcile_payment()
 
-			customer = frappe.db.get_value(
-				doctype,
-				filters,
-				customer_field
-			)
-			if customer:
-				self.customer = customer
-				return
-			
-	def _reconcile_payment(self):
-		settings = frappe.get_cached_value(
-			"Mpesa Settings", {"business_shortcode": self.businessshortcode},
-			["auto_reconcile_c2b", "auto_create_sales_invoice"],
-			as_dict=True,
-		)
+        except Exception as e:
+            frappe.log_error(
+                frappe.get_traceback(), f"C2B Reconciliation Error: {str(e)}"
+            )
 
-		if not settings.auto_reconcile_c2b or not self.payment_entry:
-			return
+    def on_cancel(self):
+        """Ensure linked Payment Entry is also cancelled when this record is cancelled."""
+        if self.payment_entry:
+            try:
+                pe = frappe.get_doc("Payment Entry", self.payment_entry)
+                if pe.docstatus == 1:
+                    pe.cancel()
+                    frappe.msgprint(
+                        _("Linked Payment Entry {0} cancelled").format(pe.name),
+                        alert=True,
+                    )
+            except Exception:
+                frappe.log_error(
+                    frappe.get_traceback(),
+                    f"Failed to cancel Payment Entry {self.payment_entry} for C2B {self.name}",
+                )
 
-		invoice, order = self._get_matching_refs()
-		
-		if order and settings.auto_create_sales_invoice:
-			self._create_sales_invoice_from_order(order)
+    def _find_customer_from_billref(self, billrefnumber: str) -> str | None:
+        if not billrefnumber:
+            return
 
-		else:
+        sources = [
+            ("Sales Invoice", "customer", {"docstatus": 1}),
+            ("Sales Order", "customer", {"docstatus": 1}),
+            ("Quotation", "party_name", {"docstatus": 1, "quotation_to": "Customer"}),
+            ("Customer", "name", {}),
+        ]
 
-			# Fallback: FIFO
-			outstanding_invoices = get_outstanding_invoices(
-				customer=self.customer, company=self.company
-			)
+        for doctype, customer_field, extra_filters in sources:
+            filters = {"name": billrefnumber}
+            filters.update(extra_filters)
 
-			if outstanding_invoices:
-				self._reconcile_against_invoice(outstanding_invoices)
+            customer = frappe.db.get_value(doctype, filters, customer_field)
+            if customer:
+                self.customer = customer
+                return
 
+    def _reconcile_payment(self):
+        settings = frappe.get_cached_value(
+            "Mpesa Settings",
+            {"business_shortcode": self.businessshortcode},
+            ["auto_reconcile_c2b", "auto_create_sales_invoice"],
+            as_dict=True,
+        )
 
-	def _get_matching_refs(self):
-		"""
-		Returns a tuple (invoice, sales_order), where exactly one is non-None if billrefnumber matched either.
-		Otherwise both are None.
-		"""
-		invoice = self._find_matching_invoice()
-		if invoice:
-			return invoice, None
-		
-		order = self._find_matching_sales_order()
-		if order:
-			return None, order
-		
-		return None, None
-	
+        if not settings.auto_reconcile_c2b or not self.payment_entry:
+            return
 
-	def _find_matching_invoice(self):
-		if not self.billrefnumber:
-			return None
+        invoice, order = self._get_matching_refs()
 
-		return frappe.get_value(
-			"Sales Invoice",
-			{
-				"name": self.billrefnumber,
-				"docstatus": 1,
-				"company": self.company,
-				"customer": self.customer,
-				"outstanding_amount": (">", 0),
-			},
-			"name"
-		)
+        if order and settings.auto_create_sales_invoice:
+            self._create_sales_invoice_from_order(order)
 
-	def _find_matching_sales_order(self):
-		if not self.billrefnumber:
-			return None
+        else:
+            # Fallback: FIFO
+            outstanding_invoices = get_outstanding_invoices(
+                customer=self.customer, company=self.company
+            )
 
-		return frappe.get_value(
-			"Sales Order",
-			{
-				"name": self.billrefnumber,
-				"docstatus": 1,
-				"company": self.company,
-				"customer": self.customer,
-				"status": ("not in", ["Closed", "Completed"]),
-			},
-			"name"
-		)
+            if outstanding_invoices:
+                self._reconcile_against_invoice(outstanding_invoices)
 
-	def _create_sales_invoice_from_order(self, sales_order):
-		try:
-			from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
+    def _get_matching_refs(self):
+        """
+        Returns a tuple (invoice, sales_order), where exactly one is non-None if billrefnumber matched either.
+        Otherwise both are None.
+        """
+        invoice = self._find_matching_invoice()
+        if invoice:
+            return invoice, None
 
-			si = make_sales_invoice(sales_order)
-			# si.allocate_advances_automatically = True
-			si.insert(ignore_permissions=True)
-			si.submit()
+        order = self._find_matching_sales_order()
+        if order:
+            return None, order
 
-			return si.name
+        return None, None
 
-		except Exception as e:
-			frappe.log_error(frappe.get_traceback(), f"Sales Invoice Creation Failed for SO {sales_order}")
-			return None
+    def _find_matching_invoice(self):
+        if not self.billrefnumber:
+            return None
 
-	def _reconcile_against_invoice(self, invoice_list):
-		if isinstance(invoice_list, str):
-			invoice_list = [invoice_list]
+        return frappe.get_value(
+            "Sales Invoice",
+            {
+                "name": self.billrefnumber,
+                "docstatus": 1,
+                "company": self.company,
+                "customer": self.customer,
+                "outstanding_amount": (">", 0),
+            },
+            "name",
+        )
 
-		create_and_reconcile_payment_reconciliation(
-			outstanding_invoices=invoice_list,
-			customer=self.customer,
-			company=self.company,
-			payment_entries=[self.payment_entry],
-		)
+    def _find_matching_sales_order(self):
+        if not self.billrefnumber:
+            return None
+
+        return frappe.get_value(
+            "Sales Order",
+            {
+                "name": self.billrefnumber,
+                "docstatus": 1,
+                "company": self.company,
+                "customer": self.customer,
+                "status": ("not in", ["Closed", "Completed"]),
+            },
+            "name",
+        )
+
+    def _create_sales_invoice_from_order(self, sales_order):
+        try:
+            from erpnext.selling.doctype.sales_order.sales_order import (
+                make_sales_invoice,
+            )
+
+            si = make_sales_invoice(sales_order)
+            # si.allocate_advances_automatically = True
+            si.insert(ignore_permissions=True)
+            si.submit()
+
+            return si.name
+
+        except Exception:
+            frappe.log_error(
+                frappe.get_traceback(),
+                f"Sales Invoice Creation Failed for SO {sales_order}",
+            )
+            return None
+
+    def _reconcile_against_invoice(self, invoice_list):
+        if isinstance(invoice_list, str):
+            invoice_list = [invoice_list]
+
+        create_and_reconcile_payment_reconciliation(
+            outstanding_invoices=invoice_list,
+            customer=self.customer,
+            company=self.company,
+            payment_entries=[self.payment_entry],
+        )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2025, Navari Limited and contributors
 # For license information, please see license.txt
 
+
 import frappe
-import re
 from frappe.model.document import Document
-from ...api.m_pesa_api import initiate_stk_push  # Import the STK push function
+
 from ....utils.utils import validate_phone_number
+from ...api.m_pesa_api import initiate_stk_push  # Import the STK push function
 
 
 class MpesaExpressRequest(Document):
@@ -14,7 +15,7 @@ class MpesaExpressRequest(Document):
             self.payment_gateway = frappe.db.get_value(
                 "Payment Gateway", {"gateway_controller": self.settings}, "name"
             )
-            
+
         if self.reference_doctype == "Payment Request":
             self.validate_payment_request_amount()
 
@@ -23,6 +24,40 @@ class MpesaExpressRequest(Document):
                 "Invalid phone number format. Please ensure it is in the correct format, e.g., 254712345678."
             )
 
+        self.validate_duplicate_c2b_records()
+
+    def validate_duplicate_c2b_records(self):
+        """Ensure any duplicate C2B is neutralized in favour of this Express Request."""
+        if not self.transaction_id:
+            return
+
+        c2b_name = frappe.db.exists(
+            "Mpesa C2B Payment Register", {"transid": self.transaction_id}
+        )
+
+        if not c2b_name:
+            return
+
+        frappe.db.savepoint("before_c2b_neutralize")
+        try:
+            c2b_doc = frappe.get_doc("Mpesa C2B Payment Register", c2b_name)
+
+            if c2b_doc.docstatus == 1:
+                c2b_doc.cancel()
+            else:
+                c2b_doc.delete()
+
+            frappe.log_error(
+                message=f"Neutralised duplicate C2B {c2b_doc.name} in favour of Express Request {self.name}",
+                title="Mpesa Express vs C2B Duplicate",
+            )
+
+        except Exception:
+            frappe.db.rollback(save_point="before_c2b_neutralize")
+            frappe.log_error(
+                frappe.get_traceback(),
+                f"Error neutralising duplicate C2B {c2b_name} for Express Request {self.name}",
+            )
 
     def validate_payment_request_amount(self):
         payment_request = frappe.get_doc("Payment Request", self.reference_name)
@@ -32,7 +67,9 @@ class MpesaExpressRequest(Document):
 
         if currency != "KES":
             if payment_request.reference_doctype and payment_request.reference_name:
-                ref_doc = frappe.get_doc(payment_request.reference_doctype, payment_request.reference_name)
+                ref_doc = frappe.get_doc(
+                    payment_request.reference_doctype, payment_request.reference_name
+                )
                 conversion_rate = getattr(ref_doc, "conversion_rate", None)
 
                 if company_currency != "KES":
@@ -42,16 +79,18 @@ class MpesaExpressRequest(Document):
                     )
 
                 if not conversion_rate:
-                    frappe.throw("Conversion rate not available to convert amount to KES.")
-                
-                self.amount = float(payment_request.grand_total) * float(conversion_rate)
+                    frappe.throw(
+                        "Conversion rate not available to convert amount to KES."
+                    )
+
+                self.amount = float(payment_request.grand_total) * float(
+                    conversion_rate
+                )
             else:
                 frappe.throw("Missing reference document to determine conversion rate.")
 
-
     def on_submit(self):
         args = {
-            "document_name": self.name,
             "payment_gateway": self.payment_gateway,
             "phone_number": self.phone_number,
             "request_amount": self.amount,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
@@ -24,41 +24,6 @@ class MpesaExpressRequest(Document):
                 "Invalid phone number format. Please ensure it is in the correct format, e.g., 254712345678."
             )
 
-        self.validate_duplicate_c2b_records()
-
-    def validate_duplicate_c2b_records(self):
-        """Ensure any duplicate C2B is neutralized in favour of this Express Request."""
-        if not self.transaction_id:
-            return
-
-        c2b_name = frappe.db.exists(
-            "Mpesa C2B Payment Register", {"transid": self.transaction_id}
-        )
-
-        if not c2b_name:
-            return
-
-        frappe.db.savepoint("before_c2b_neutralize")
-        try:
-            c2b_doc = frappe.get_doc("Mpesa C2B Payment Register", c2b_name)
-
-            if c2b_doc.docstatus == 1:
-                c2b_doc.cancel()
-            else:
-                c2b_doc.delete()
-
-            frappe.log_error(
-                message=f"Neutralised duplicate C2B {c2b_doc.name} in favour of Express Request {self.name}",
-                title="Mpesa Express vs C2B Duplicate",
-            )
-
-        except Exception:
-            frappe.db.rollback(save_point="before_c2b_neutralize")
-            frappe.log_error(
-                frappe.get_traceback(),
-                f"Error neutralising duplicate C2B {c2b_name} for Express Request {self.name}",
-            )
-
     def validate_payment_request_amount(self):
         payment_request = frappe.get_doc("Payment Request", self.reference_name)
         currency = payment_request.currency
@@ -104,3 +69,40 @@ class MpesaExpressRequest(Document):
         except Exception as e:
             frappe.log_error(frappe.get_traceback(), "STK Push on Submit Error")
             frappe.throw(f"Failed to initiate STK Push: {str(e)}")
+
+    def on_update_after_submit(self):
+        """Neutralize duplicate C2B when transaction_id is finally set after callback."""
+        self.validate_duplicate_c2b_records()
+
+    def validate_duplicate_c2b_records(self):
+        """Ensure any duplicate C2B is neutralized in favour of this Express Request."""
+        if not self.transaction_id:
+            return
+
+        c2b_name = frappe.db.exists(
+            "Mpesa C2B Payment Register", {"transid": self.transaction_id}
+        )
+
+        if not c2b_name:
+            return
+
+        frappe.db.savepoint("before_c2b_neutralize")
+        try:
+            c2b_doc = frappe.get_doc("Mpesa C2B Payment Register", c2b_name)
+
+            if c2b_doc.docstatus == 1:
+                c2b_doc.cancel()
+            else:
+                c2b_doc.delete()
+
+            frappe.log_error(
+                message=f"Neutralised duplicate C2B {c2b_doc.name} in favour of Express Request {self.name}",
+                title="Mpesa Express vs C2B Duplicate",
+            )
+
+        except Exception:
+            frappe.db.rollback(save_point="before_c2b_neutralize")
+            frappe.log_error(
+                frappe.get_traceback(),
+                f"Error neutralising duplicate C2B {c2b_name} for Express Request {self.name}",
+            )


### PR DESCRIPTION
## Description

This PR introduces multiple improvements to the M-Pesa integration to ensure data consistency and proper handling of duplicate transactions between Express Requests and C2B payments.

### Key changes

- **Async C2B insertion:**  
  Queues C2B Payment Register creation to run asynchronously after receiving confirmation. This prevents race conditions with existing Express Requests for the same transaction.

- **Duplicate prevention:**  
  - Express Requests now automatically neutralize any matching C2B records.  
  - C2B insertion is skipped if a corresponding Express Request exists, with proper logging for traceability.

- **Post-submit neutralization:**  
  Moves duplicate neutralization from validation to post-submit and callback hooks, ensuring `transaction_id` is reliably available before attempting cancellation.

- **Improved API reliability:**  
  - STK push password generation refactored to prevent authentication errors caused by whitespace or encoding issues.  
  - Transaction status queries no longer retry indefinitely; failures are now logged and marked as “Failed” immediately.

- **Logging & traceability:**  
  All major operations now log detailed errors to help with debugging and audit trails.

### Impact

- Prevents duplicate payments from being recorded.  
- Ensures Express Requests take precedence over C2B payments.  
- Improves overall reliability and consistency of M-Pesa transaction processing.
