### PR TITLE
refactor: Rename Mpesa Reconciliation Order to Mpesa Reconciliation Priority

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_reconciliation_priority/mpesa_reconciliation_priority.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_reconciliation_priority/mpesa_reconciliation_priority.json
@@ -46,7 +46,7 @@
  "modified": "2025-12-08 08:57:37.769408",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
- "name": "Mpesa Reconciliation Order",
+ "name": "Mpesa Reconciliation Priority",
  "owner": "Administrator",
  "permissions": [],
  "row_format": "Dynamic",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_reconciliation_priority/mpesa_reconciliation_priority.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_reconciliation_priority/mpesa_reconciliation_priority.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class MpesaReconciliationOrder(Document):
+class MpesaReconciliationPriority(Document):
 	pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -150,7 +150,7 @@ frappe.ui.form.on("Mpesa Settings", {
 	},
 });
 
-frappe.ui.form.on("Mpesa Reconciliation Order", {
+frappe.ui.form.on("Mpesa Reconciliation Priority", {
 	target_doctype: function (frm, cdt, cdn) {
 		frm.events.update_match_field_options(frm, cdt, cdn);
 	},

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -249,11 +249,11 @@
    "fieldtype": "Table",
    "label": "Reconciliation Order",
    "mandatory_depends_on": "eval: doc.auto_reconcile_c2b",
-   "options": "Mpesa Reconciliation Order"
+   "options": "Mpesa Reconciliation Priority"
   }
  ],
  "links": [],
- "modified": "2025-12-08 09:05:54.289224",
+ "modified": "2025-12-09 09:25:04.686174",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",


### PR DESCRIPTION
This commit renames the Mpesa Reconciliation Order DocType to Mpesa Reconciliation Priority.

The change was made to better reflect the purpose of the DocType, which is to define the priority and rules for reconciliation rather than an 'order' in the sequential sense.

This refactoring includes:

Renaming the DocType directory and associated files (__init__.py, .json, .py).
Updating the name field within the DocType's JSON definition.
Updating the Python class name in the DocType's .py file.
Updating all references to the old DocType name in related files, specifically in mpesa_settings.js and mpesa_settings.json.