### PR TITLE
feat(install): Add after_install hook to update Mpesa Settings module

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/migrate.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/migrate.py
@@ -11,6 +11,9 @@ def is_app_installed(app_name: str) -> bool:
 
 
 def after_migrate():
+    if is_app_installed("payments"):
+        update_settings_module()
+
     if is_app_installed("erpnext"):
         create_custom_pos_fields()
         create_custom_erpnext_fields()
@@ -21,6 +24,13 @@ def after_migrate():
 
     if is_app_installed("hrms"):
         create_custom_hrms_fields()
+
+
+def update_settings_module():
+    current_module = frappe.db.get_value("DocType", "Mpesa Settings", "module")
+    if current_module != MODULE:
+        frappe.db.set_value("DocType", "Mpesa Settings", "module", MODULE)
+        frappe.reload_doctype("Mpesa Settings")
 
 
 def create_custom_lending_fields():

--- a/frappe_mpsa_payments/hooks.py
+++ b/frappe_mpsa_payments/hooks.py
@@ -100,7 +100,7 @@ doctype_js = {
 # ------------
 
 # before_install = "frappe_mpsa_payments.install.before_install"
-# after_install = "frappe_mpsa_payments.install.after_install"
+after_install = "frappe_mpsa_payments.frappe_mpsa_payments.migrate.after_migrate"
 
 # Uninstallation
 # ------------


### PR DESCRIPTION
This pull request updates the migration logic and installation hooks for the `frappe_mpsa_payments` app to ensure proper configuration when related apps are present. The main changes focus on updating the settings module for Mpesa when the `payments` app is installed, and configuring the installation hook to use the new migration function.

**Migration and installation logic improvements:**

* Added a call to `update_settings_module()` in the `after_migrate()` function, which updates the `Mpesa Settings` DocType module and reloads it if the `payments` app is installed.
* Implemented the new `update_settings_module()` function to handle updating the `Mpesa Settings` module assignment and reloading the DocType.
* Updated the `after_install` hook in `hooks.py` to use the `after_migrate` function from the migration module, ensuring the new logic is executed after installation.