### PR TITLE
Improve Mpesa Transaction Status Handling with Realtime Callback Updates

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -770,10 +770,11 @@ def process_mpesa_integration_request(integration_request, response_data):
         }
 
         result_code = result_data.get("ResultCode", None)
+        result_desc = result_data.get("ResultDesc", "Unknown Error")
         receipt_no = result_params.get("ReceiptNo", "")
 
         if result_code != 0:
-            error_msg = f"Transaction failed with result code: {result_code}"
+            error_msg = f"Result Code {result_code}: {result_desc}"
             integration_request.status = "Failed"
             integration_request.output = error_msg
             integration_request.save(ignore_permissions=True)
@@ -785,6 +786,8 @@ def process_mpesa_integration_request(integration_request, response_data):
                     "status": "error",
                     "title": "Transaction Failed",
                     "message": error_msg,
+                    "result_code": result_code,
+                    "result_desc": result_desc,
                     "receipt_no": receipt_no,
                 },
             )
@@ -807,7 +810,7 @@ def process_mpesa_integration_request(integration_request, response_data):
                 event="mpesa_transaction_status_update",
                 message={
                     "status": "warning",
-                    "title": "Duplicate Transaction",
+                    "title": "Duplicate M-Pesa Transaction",
                     "message": error_msg,
                     "receipt_no": receipt_no,
                 },

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -785,7 +785,7 @@ def process_mpesa_integration_request(integration_request, response_data):
             frappe.db.set_value(
                 "Integration Request",
                 integration_request,
-                {"status": "Failed", "output": error_msg},
+                {"status": "Failed", "error": error_msg},
                 update_modified=True,
             )
             frappe.db.commit()

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -728,17 +728,12 @@ def handle_transaction_status_result():
             return {"ResultCode": 1, "ResultDesc": "Empty response data"}
 
         integration_request = frappe.get_doc(
+            "Integration Request",
             {
-                "doctype": "Integration Request",
-                "is_remote_request": 1,
-                "integration_request_service": "Mpesa Transaction Status Result Callback",
-                "reference_doctype": "Mpesa C2B Payment Register",
-                "status": "Queued",
-                "data": json.dumps(response_data),
-                "url": frappe.request.url,
-                "method": "POST",
-            }
-        ).insert(ignore_permissions=True)
+                "integration_request_service": "Mpesa Transaction Status",
+                "reference_docname": response["OriginatorConversationID"],
+            },
+        )
         frappe.db.commit()
 
         result = process_mpesa_integration_request(integration_request, response_data)
@@ -790,6 +785,7 @@ def process_mpesa_integration_request(integration_request, response_data):
                     "result_desc": result_desc,
                     "receipt_no": receipt_no,
                 },
+                user=integration_request.owner,
             )
 
             return {"ResultCode": 0, "ResultDesc": "Accepted (failed transaction)"}
@@ -814,6 +810,7 @@ def process_mpesa_integration_request(integration_request, response_data):
                     "message": error_msg,
                     "receipt_no": receipt_no,
                 },
+                user=integration_request.owner,
             )
 
             return {"ResultCode": 0, "ResultDesc": "Duplicate transaction rejected"}
@@ -861,6 +858,7 @@ def process_mpesa_integration_request(integration_request, response_data):
                 "receipt_no": receipt_no,
                 "document_name": mpesa_doc.name,
             },
+            user=integration_request.owner,
         )
 
         return {"ResultCode": 0, "ResultDesc": success_msg}
@@ -884,6 +882,7 @@ def process_mpesa_integration_request(integration_request, response_data):
                 "title": "Processing Error",
                 "message": error_message,
             },
+            user=integration_request.owner,
         )
 
         return {"ResutlCode": 1, "ResultDesc": "Processing failed"}

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -727,14 +727,23 @@ def handle_transaction_status_result():
             frappe.log_error("Empty response from Mpesa", "Mpesa Webhook Error")
             return {"ResultCode": 1, "ResultDesc": "Empty response data"}
 
-        integration_request = frappe.get_doc(
+        correlation_id = response_data.get("Result", {}).get("OriginatorConversationID")
+        integration_request = frappe.db.get_value(
             "Integration Request",
             {
                 "integration_request_service": "Mpesa Transaction Status",
-                "reference_docname": response["OriginatorConversationID"],
+                "request_id": correlation_id,
             },
+            "name",
         )
         frappe.db.commit()
+
+        if not integration_request:
+            frappe.log_error(
+                f"Could not find Integration Request for OriginatorConversationID {correlation_id}",
+                "Mpesa Webhook Error",
+            )
+            return {"ResultCode": 1, "ResultDesc": "Integration Request not found"}
 
         result = process_mpesa_integration_request(integration_request, response_data)
 
@@ -754,6 +763,9 @@ def handle_transaction_status_result():
 def process_mpesa_integration_request(integration_request, response_data):
     """Process the Mpesa Integration Request and publish updates in real-time"""
     try:
+        ir_owner = frappe.db.get_value(
+            "Integration Request", integration_request, "owner"
+        )
         result_data = response_data.get("Result", {})
         result_parameters = result_data.get("ResultParameters", {}).get(
             "ResultParameter", []
@@ -770,9 +782,12 @@ def process_mpesa_integration_request(integration_request, response_data):
 
         if result_code != 0:
             error_msg = f"Result Code {result_code}: {result_desc}"
-            integration_request.status = "Failed"
-            integration_request.output = error_msg
-            integration_request.save(ignore_permissions=True)
+            frappe.db.set_value(
+                "Integration Request",
+                integration_request,
+                {"status": "Failed", "output": error_msg},
+                update_modified=True,
+            )
             frappe.db.commit()
 
             frappe.publish_realtime(
@@ -785,16 +800,19 @@ def process_mpesa_integration_request(integration_request, response_data):
                     "result_desc": result_desc,
                     "receipt_no": receipt_no,
                 },
-                user=integration_request.owner,
+                user=ir_owner,
             )
 
             return {"ResultCode": 0, "ResultDesc": "Accepted (failed transaction)"}
 
         if frappe.db.exists("Mpesa C2B Payment Register", {"transid": receipt_no}):
             error_msg = f"Duplicate transaction: Receipt No {receipt_no} already exists"
-            integration_request.status = "Failed"
-            integration_request.output = error_msg
-            integration_request.save(ignore_permissions=True)
+            frappe.db.set_value(
+                "Integration Request",
+                integration_request,
+                {"status": "Failed", "error": error_msg},
+                update_modified=True,
+            )
             frappe.db.commit()
 
             frappe.log_error(
@@ -810,7 +828,7 @@ def process_mpesa_integration_request(integration_request, response_data):
                     "message": error_msg,
                     "receipt_no": receipt_no,
                 },
-                user=integration_request.owner,
+                user=ir_owner,
             )
 
             return {"ResultCode": 0, "ResultDesc": "Duplicate transaction rejected"}
@@ -843,10 +861,16 @@ def process_mpesa_integration_request(integration_request, response_data):
         frappe.db.commit()
 
         success_msg = "Transaction processed successfully"
-        integration_request.status = "Completed"
-        integration_request.output = success_msg
-        integration_request.reference_document = mpesa_doc.name
-        integration_request.save(ignore_permissions=True)
+        frappe.db.set_value(
+            "Integration Request",
+            integration_request,
+            {
+                "status": "Completed",
+                "output": success_msg,
+                "reference_document": mpesa_doc.name,
+            },
+            update_modified=True,
+        )
         frappe.db.commit()
 
         frappe.publish_realtime(
@@ -858,16 +882,19 @@ def process_mpesa_integration_request(integration_request, response_data):
                 "receipt_no": receipt_no,
                 "document_name": mpesa_doc.name,
             },
-            user=integration_request.owner,
+            user=ir_owner,
         )
 
         return {"ResultCode": 0, "ResultDesc": success_msg}
 
     except Exception as e:
         error_message = f"Mpesa Processing Error: {str(e)}"
-        integration_request.status = "Failed"
-        integration_request.output = error_message
-        integration_request.save(ignore_permissions=True)
+        frappe.db.set_value(
+            "Integration Request",
+            integration_request,
+            {"status": "Failed", "error": error_message},
+            update_modified=True,
+        )
         frappe.db.commit()
 
         frappe.log_error(
@@ -882,7 +909,7 @@ def process_mpesa_integration_request(integration_request, response_data):
                 "title": "Processing Error",
                 "message": error_message,
             },
-            user=integration_request.owner,
+            user=ir_owner,
         )
 
         return {"ResutlCode": 1, "ResultDesc": "Processing failed"}

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -723,6 +723,10 @@ def handle_transaction_status_result():
         response = frappe.request.data
         response_data = json.loads(response)
 
+        if not response_data:
+            frappe.log_error("Empty response from Mpesa", "Mpesa Webhook Error")
+            return {"ResultCode": 1, "ResultDesc": "Empty response data"}
+
         integration_request = frappe.get_doc(
             {
                 "doctype": "Integration Request",
@@ -737,37 +741,24 @@ def handle_transaction_status_result():
         ).insert(ignore_permissions=True)
         frappe.db.commit()
 
-        frappe.enqueue(
-            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_mpesa_integration_request",
-            queue="short",
-            timeout=300,
-            job_id=f"mpesa_process_{integration_request.name}",
-            integration_request_name=integration_request.name,
-            deduplicate=True,
-        )
+        result = process_mpesa_integration_request(integration_request, response_data)
 
-        return {"status": "queued", "message": "Transaction queued for processing"}
+        return result
 
     except json.JSONDecodeError as e:
         frappe.log_error(
-            f"Failed to decode JSON from Mpesa response: {str(e)}", "Mpesa API Error"
+            f"Failed to decode JSON from Mpesa response: {str(e)}",
+            "Mpesa Webhook Error",
         )
-        return {"status": "error", "message": "Invalid JSON data"}
+        return {"ResultCode": 1, "ResultDesc": "Invalid JSON data"}
     except Exception as e:
-        frappe.log_error(f"Error in Mpesa webhook: {str(e)}", "Mpesa API Error")
-        return {"status": "error", "message": f"Webhook error: {str(e)}"}
+        frappe.log_error(f"Error in Mpesa webhook: {str(e)}", "Mpesa Webhook Error")
+        return {"ResultCode": 1, "ResultDesc": "Processing error"}
 
 
-def process_mpesa_integration_request(integration_request_name):
+def process_mpesa_integration_request(integration_request, response_data):
     """Process the Mpesa Integration Request and publish updates in real-time"""
     try:
-        # Fetch the Integration Request
-        integration_request = frappe.get_doc(
-            "Integration Request", integration_request_name
-        )
-
-        # Parse the stored data
-        response_data = json.loads(integration_request.data)
         result_data = response_data.get("Result", {})
         result_parameters = result_data.get("ResultParameters", {}).get(
             "ResultParameter", []
@@ -780,81 +771,63 @@ def process_mpesa_integration_request(integration_request_name):
 
         result_code = result_data.get("ResultCode", None)
         receipt_no = result_params.get("ReceiptNo", "")
-        business_shortcode = result_params.get("CreditPartyName", "").split("-")
 
-        if result_code == 0:
-            if frappe.db.exists("Mpesa C2B Payment Register", {"transid": receipt_no}):
-                error_msg = (
-                    f"Duplicate transaction: Receipt No {receipt_no} already exists"
-                )
-                integration_request.status = "Failed"
-                integration_request.output = error_msg
-                integration_request.save(ignore_permissions=True)
-                frappe.db.commit()
-
-                frappe.publish_realtime(
-                    event="mpesa_transaction_status",
-                    message={"status": "error", "message": error_msg},
-                    user=frappe.session.user,
-                )
-                return
-
-            # Create the Mpesa document
-            mpesa_doc = frappe.new_doc("Mpesa C2B Payment Register")
-            mpesa_doc.full_name = result_params.get("DebitPartyName", "")
-            mpesa_doc.transactiontype = result_params.get("ReasonType", "")
-            mpesa_doc.transid = result_params.get("ReceiptNo", "")
-            mpesa_doc.transtime = result_params.get("InitiatedTime", "")
-            mpesa_doc.transamount = float(result_params.get("Amount", 0.0))
-            mpesa_doc.businessshortcode = business_shortcode[0]
-            mpesa_doc.billrefnumber = result_params.get("ReceiptNo", "")
-            mpesa_doc.invoicenumber = result_params.get("TransactionID", "")
-            mpesa_doc.orgaccountbalance = result_params.get("DebitAccountType", "")
-            mpesa_doc.thirdpartytransid = result_params.get(
-                "OriginatorConversationID", ""
-            )
-
-            debit_party = result_params.get("DebitPartyName", "").split(" - ")
-            mpesa_doc.msisdn = debit_party[0] if len(debit_party) > 0 else ""
-            name_parts = (
-                debit_party[1].split(" ") if len(debit_party) > 1 else ["", "", ""]
-            )
-            mpesa_doc.firstname = name_parts[0]
-            mpesa_doc.middlename = name_parts[1] if len(name_parts) > 1 else ""
-            mpesa_doc.lastname = name_parts[-1] if len(name_parts) > 2 else ""
-
-            mpesa_doc.insert(ignore_permissions=True)
-            frappe.db.commit()
-
-            success_msg = "Transaction processed successfully"
-            integration_request.status = "Completed"
-            integration_request.output = success_msg
-            integration_request.reference_document = mpesa_doc.name
+        if result_code != 0:
+            error_msg = f"Transaction failed with result code: {result_code}"
+            integration_request.status = "Failed"
+            integration_request.output = error_msg
             integration_request.save(ignore_permissions=True)
             frappe.db.commit()
+            return {"ResultCode": 0, "ResultDesc": "Accepted (failed transaction)"}
 
-            frappe.publish_realtime(
-                event="mpesa_transaction_status",
-                message={
-                    "status": "success",
-                    "message": success_msg,
-                    "doc_name": mpesa_doc.name,
-                },
-                user=frappe.session.user,
-            )
-
-        else:
-            error_msg = "Transaction failed with non-zero result code"
+        if frappe.db.exists("Mpesa C2B Payment Register", {"transid": receipt_no}):
+            error_msg = f"Duplicate transaction: Receipt No {receipt_no} already exists"
             integration_request.status = "Failed"
             integration_request.output = error_msg
             integration_request.save(ignore_permissions=True)
             frappe.db.commit()
 
-            frappe.publish_realtime(
-                event="mpesa_transaction_status",
-                message={"status": "error", "message": error_msg},
-                user=frappe.session.user,
+            frappe.log_error(
+                title=f"Duplicate M-Pesa Transaction: {receipt_no}",
+                message=f"Transaction ID: {receipt_no}\nFull Data: {json.dumps(response_data, indent=2)}",
             )
+            return {"ResultCode": 0, "ResultDesc": "Duplicate transaction rejected"}
+
+        business_shortcode = result_params.get("CreditPartyName", "").split("-")
+        debit_party = result_params.get("DebitPartyName", "").split(" - ")
+        name_parts = debit_party[1].split(" ") if len(debit_party) > 1 else ["", "", ""]
+
+        # Create the Mpesa document
+        mpesa_doc = frappe.new_doc("Mpesa C2B Payment Register")
+        mpesa_doc.full_name = result_params.get("DebitPartyName", "")
+        mpesa_doc.transactiontype = result_params.get("ReasonType", "")
+        mpesa_doc.transid = receipt_no
+        mpesa_doc.transtime = result_params.get("InitiatedTime", "")
+        mpesa_doc.transamount = float(result_params.get("Amount", 0.0))
+        mpesa_doc.businessshortcode = (
+            business_shortcode[0] if business_shortcode else ""
+        )
+        mpesa_doc.billrefnumber = receipt_no
+        mpesa_doc.invoicenumber = result_params.get("TransactionID", "")
+        mpesa_doc.orgaccountbalance = result_params.get("DebitAccountType", "")
+        mpesa_doc.thirdpartytransid = result_params.get("OriginatorConversationID", "")
+
+        mpesa_doc.msisdn = debit_party[0] if len(debit_party) > 0 else ""
+        mpesa_doc.firstname = name_parts[0]
+        mpesa_doc.middlename = name_parts[1] if len(name_parts) > 1 else ""
+        mpesa_doc.lastname = name_parts[-1] if len(name_parts) > 2 else ""
+
+        mpesa_doc.insert(ignore_permissions=True)
+        frappe.db.commit()
+
+        success_msg = "Transaction processed successfully"
+        integration_request.status = "Completed"
+        integration_request.output = success_msg
+        integration_request.reference_document = mpesa_doc.name
+        integration_request.save(ignore_permissions=True)
+        frappe.db.commit()
+
+        return {"ResultCode": 0, "ResultDesc": success_msg}
 
     except Exception as e:
         error_message = f"Mpesa Processing Error: {str(e)}"
@@ -864,14 +837,11 @@ def process_mpesa_integration_request(integration_request_name):
         frappe.db.commit()
 
         frappe.log_error(
+            "Mpesa Transaction Processing Error",
             f"{error_message}\nData: {integration_request.data}",
-            "Mpesa Integration Error",
         )
-        frappe.publish_realtime(
-            event="mpesa_transaction_status",
-            message={"status": "error", "message": error_message},
-            user=frappe.session.user,
-        )
+
+        return {"ResutlCode": 1, "ResultDesc": "Processing failed"}
 
 
 @frappe.whitelist(allow_guest=True)

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -778,6 +778,17 @@ def process_mpesa_integration_request(integration_request, response_data):
             integration_request.output = error_msg
             integration_request.save(ignore_permissions=True)
             frappe.db.commit()
+
+            frappe.publish_realtime(
+                event="mpesa_transaction_status_update",
+                message={
+                    "status": "error",
+                    "title": "Transaction Failed",
+                    "message": error_msg,
+                    "receipt_no": receipt_no,
+                },
+            )
+
             return {"ResultCode": 0, "ResultDesc": "Accepted (failed transaction)"}
 
         if frappe.db.exists("Mpesa C2B Payment Register", {"transid": receipt_no}):
@@ -791,6 +802,17 @@ def process_mpesa_integration_request(integration_request, response_data):
                 title=f"Duplicate M-Pesa Transaction: {receipt_no}",
                 message=f"Transaction ID: {receipt_no}\nFull Data: {json.dumps(response_data, indent=2)}",
             )
+
+            frappe.publish_realtime(
+                event="mpesa_transaction_status_update",
+                message={
+                    "status": "warning",
+                    "title": "Duplicate Transaction",
+                    "message": error_msg,
+                    "receipt_no": receipt_no,
+                },
+            )
+
             return {"ResultCode": 0, "ResultDesc": "Duplicate transaction rejected"}
 
         business_shortcode = result_params.get("CreditPartyName", "").split("-")
@@ -827,6 +849,17 @@ def process_mpesa_integration_request(integration_request, response_data):
         integration_request.save(ignore_permissions=True)
         frappe.db.commit()
 
+        frappe.publish_realtime(
+            event="mpesa_transaction_status_update",
+            message={
+                "status": "success",
+                "title": "Transaction Successful",
+                "message": success_msg,
+                "receipt_no": receipt_no,
+                "document_name": mpesa_doc.name,
+            },
+        )
+
         return {"ResultCode": 0, "ResultDesc": success_msg}
 
     except Exception as e:
@@ -839,6 +872,15 @@ def process_mpesa_integration_request(integration_request, response_data):
         frappe.log_error(
             "Mpesa Transaction Processing Error",
             f"{error_message}\nData: {integration_request.data}",
+        )
+
+        frappe.publish_realtime(
+            event="mpesa_transaction_status_update",
+            message={
+                "status": "error",
+                "title": "Processing Error",
+                "message": error_message,
+            },
         )
 
         return {"ResutlCode": 1, "ResultDesc": "Processing failed"}

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
@@ -21,6 +21,8 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 						label: "Remarks",
 						fieldname: "remarks",
 						fieldtype: "Small Text",
+						default: "OK",
+						hidden: 1,
 					},
 				],
 				(values) => {
@@ -38,6 +40,7 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 										"Please set the initiator name and security credential in the selected Mpesa Settings"
 									)
 								);
+								return;
 							}
 
 							frappe.call({
@@ -45,12 +48,12 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 								args: {
 									mpesa_settings: values.mpesa_settings,
 									transaction_id: values.transaction_id,
-									remarks: values.remarks,
+									remarks: values.remarks || "OK",
 								},
+								freeze: true,
+								freeze_message: __("Checking transaction status..."),
 								callback: (r) => {
-									if (r.message && r.message.status === "queued") {
-										// Wait for the transaction status to be processed
-									} else {
+									if (r.message) {
 										frappe.msgprint({
 											message: __(r.message.message),
 											title:
@@ -58,11 +61,17 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 											indicator:
 												r.message.status === "error" ? "red" : "green",
 										});
+
+										if (r.message.status === "success") {
+											listview.refresh();
+										}
 									}
 								},
 								error: (err) => {
 									frappe.msgprint({
-										message: __("An error occurred: {0}", [err.message]),
+										message: __("An error occurred: {0}", [
+											err.message || "Unknown error",
+										]),
 										title: "Error",
 										indicator: "red",
 									});
@@ -74,19 +83,6 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 				__("Transaction Status Query"),
 				__("Submit")
 			);
-		});
-	},
-
-	refresh: function (listview) {
-		frappe.realtime.on("mpesa_transaction_status", function (data) {
-			frappe.msgprint({
-				message: __(data.message),
-				title: data.status === "success" ? "Success" : "Error",
-				indicator: data.status === "success" ? "green" : "red",
-			});
-			if (data.status === "success" && data.doc_name) {
-				listview.refresh();
-			}
 		});
 	},
 };

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
@@ -1,5 +1,33 @@
 frappe.listview_settings["Mpesa C2B Payment Register"] = {
 	onload: function (listview) {
+		// Register realtime listener
+		if (!listview._mpesa_realtime_registered) {
+			listview._mpesa_realtime_registered = true;
+
+			frappe.realtime.on("mpesa_transaction_status_update", (data) => {
+				frappe.hide_progress();
+
+				frappe.msgprint({
+					message: __(data.message),
+					title: __(data.title),
+					indicator:
+						data.status === "error"
+							? "red"
+							: data.status === "warning"
+							? "orange"
+							: "green",
+				});
+
+				if (data.document_name) {
+					frappe.show_alert({
+						message: __("View transaction: {0}", [data.document_name]),
+						indicator: "green",
+					});
+				}
+
+				listview.refresh();
+			});
+		}
 		// Add a custom button to the page actions (top bar)
 		listview.page.add_inner_button(__("Check Transaction Status"), function () {
 			frappe.prompt(
@@ -54,20 +82,25 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 								freeze_message: __("Checking transaction status..."),
 								callback: (r) => {
 									if (r.message) {
-										frappe.msgprint({
-											message: __(r.message.message),
-											title:
-												r.message.status === "error" ? "Error" : "Success",
-											indicator:
-												r.message.status === "error" ? "red" : "green",
-										});
-
-										if (r.message.status === "success") {
-											listview.refresh();
+										if (r.message.status === "error") {
+											frappe.hide_progress();
+											frappe.msgprint({
+												message: __(r.message.message),
+												title: __("Error"),
+												indicator: "red",
+											});
+										} else {
+											frappe.show_progress(
+												__("Processing"),
+												50,
+												100,
+												__("Waiting for M-Pesa callback...")
+											);
 										}
 									}
 								},
 								error: (err) => {
+									frappe.hide_progress();
 									frappe.msgprint({
 										message: __("An error occurred: {0}", [
 											err.message || "Unknown error",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -41,6 +41,29 @@ frappe.ui.form.on("Mpesa Settings", {
 			frappe.throw(__("Please set the initiator name and the security credential"));
 			return;
 		}
+
+		frappe.realtime.on("mpesa_transaction_status_update", (data) => {
+			frappe.hide_progress();
+
+			frappe.msgprint({
+				message: __(data.message),
+				title: __(data.title),
+				indicator:
+					data.status === "error"
+						? "red"
+						: data.status === "warning"
+						? "orange"
+						: "green",
+			});
+
+			if (data.document_name) {
+				frappe.show_alert({
+					message: __("View transaction: {0}", [data.document_name]),
+					indicator: "green",
+				});
+			}
+		});
+
 		frappe.prompt(
 			[
 				{
@@ -69,14 +92,25 @@ frappe.ui.form.on("Mpesa Settings", {
 					freeze_message: __("Checking transaction status..."),
 					callback: (r) => {
 						if (r.message) {
-							frappe.msgprint({
-								message: __(r.message.message),
-								title: r.message.status === "error" ? __("Error") : __("Success"),
-								indicator: r.message.status === "error" ? "red" : "green",
-							});
+							if (r.message.status === "error") {
+								frappe.hide_progress();
+								frappe.msgprint({
+									message: __(r.message.message),
+									title: __("Error"),
+									indicator: "red",
+								});
+							} else {
+								frappe.show_progress(
+									__("Processing"),
+									50,
+									100,
+									__("Waiting for M-Pesa callback...")
+								);
+							}
 						}
 					},
 					error: (err) => {
+						frappe.hide_progress();
 						frappe.msgprint({
 							message: __("An error occurred: {0}", [
 								err.message || "Unknown error",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -39,8 +39,8 @@ frappe.ui.form.on("Mpesa Settings", {
 	check_transaction_status: function (frm) {
 		if (!frm.doc.initiator_name && !frm.doc.security_credential) {
 			frappe.throw(__("Please set the initiator name and the security credential"));
+			return;
 		}
-		frappe.clear_cache;
 		frappe.prompt(
 			[
 				{
@@ -53,6 +53,8 @@ frappe.ui.form.on("Mpesa Settings", {
 					label: "Remarks",
 					fieldname: "remarks",
 					fieldtype: "Small Text",
+					default: "OK",
+					hidden: 1,
 				},
 			],
 			(values) => {
@@ -61,25 +63,24 @@ frappe.ui.form.on("Mpesa Settings", {
 					args: {
 						mpesa_settings: frm.doc.name,
 						transaction_id: values.transaction_id,
-						remarks: values.remarks,
+						remarks: values.remarks || "OK",
 					},
+					freeze: true,
+					freeze_message: __("Checking transaction status..."),
 					callback: (r) => {
-						if (r.message && r.message.status === "queued") {
-							frappe.show_alert({
-								message: __("Request queued and will be processed shortly"),
-								indicator: "orange",
-							});
-						} else {
+						if (r.message) {
 							frappe.msgprint({
 								message: __(r.message.message),
-								title: r.message.status === "error" ? "Error" : "Success",
+								title: r.message.status === "error" ? __("Error") : __("Success"),
 								indicator: r.message.status === "error" ? "red" : "green",
 							});
 						}
 					},
 					error: (err) => {
 						frappe.msgprint({
-							message: __("An error occurred: {0}", [err.message]),
+							message: __("An error occurred: {0}", [
+								err.message || "Unknown error",
+							]),
 							title: "Error",
 							indicator: "red",
 						});

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -493,6 +493,7 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
         if response.get("ResponseCode") == "0":
             integration_request.status = "Completed"
             integration_request.output = dumps(response)
+            integration_request.reference_docname = response["OriginatorConversationID"]
             integration_request.save(ignore_permissions=True)
             frappe.db.commit()  # nosegrep
 

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -490,13 +490,27 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
             result_url=result_url,
         )
 
-        if response.get("ResponseCode") == "0":
-            integration_request.status = "Completed"
-            integration_request.output = dumps(response)
-            integration_request.reference_docname = response["OriginatorConversationID"]
-            integration_request.save(ignore_permissions=True)
-            frappe.db.commit()  # nosegrep
+        status = "Completed" if response.get("ResponseCode") == "0" else "Failed"
+        output = (
+            frappe.as_json(response)
+            if status == "Completed"
+            else f"{response.get('errorCode', 'Unknown')}: {response.get('errorMessage', 'Unknown error')}"
+        )
 
+        frappe.db.set_value(
+            "Integration Request",
+            integration_request.name,
+            {
+                "status": status,
+                "output": output,
+                "request_id": response.get("OriginatorConversationID"),
+            },
+            update_modified=True,
+        )
+
+        frappe.db.commit()  # nosegrep
+
+        if status == "Completed":
             return {
                 "status": "success",
                 "message": response.get(
@@ -506,19 +520,16 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
             }
 
         else:
-            error_msg = f"{response.get('errorCode', 'Unknown')}: {response.get('errorMessage', 'Unknown error')}"
-            integration_request.status = "Failed"
-            integration_request.output = error_msg
-            integration_request.save(ignore_permissions=True)
-            frappe.db.commit()
-
-            return {"status": "error", "message": error_msg}
+            return {"status": "error", "message": output}
 
     except Exception as e:
         if "integration_request" in locals():
-            integration_request.status = "Failed"
-            integration_request.output = str(e)
-            integration_request.save(ignore_permissions=True)
+            frappe.db.set_value(
+                "Integration Request",
+                integration_request.name,
+                {"status": "Failed", "output": str(e)},
+                update_modified=True,
+            )
             frappe.db.commit()  # nosegrep
 
         frappe.log_error(title="Mpesa Transaction Status Error", message=str(e))

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -447,6 +447,8 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
             + "/api/method/frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.handle_transaction_status_result"
         )
 
+        settings = frappe.get_doc("Mpesa Settings", mpesa_settings)
+
         integration_request = frappe.get_doc(
             {
                 "doctype": "Integration Request",
@@ -468,47 +470,6 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
         ).insert(ignore_permissions=True)
         frappe.db.commit()
 
-        frappe.enqueue(
-            "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.process_transaction_status",
-            queue="short",
-            timeout=300,
-            job_id=f"mpesa_status_{integration_request.name}",
-            integration_request_name=integration_request.name,
-            deduplicate=True,
-        )
-
-        frappe.publish_realtime(
-            event="mpesa_transaction_status",
-            message={
-                "status": "queued",
-                "message": _("Transaction status check queued for processing"),
-            },
-            user=frappe.session.user,
-        )
-        return {"status": "queued", "message": "Transaction status check queued"}
-
-    except Exception as e:
-        frappe.log_error(title="Mpesa Transaction Status Queue Error", message=str(e))
-        return {"status": "error", "message": str(e)}
-
-
-def process_transaction_status(integration_request_name):
-    """Process the Mpesa transaction status check in the background"""
-    try:
-        integration_request = frappe.get_doc(
-            "Integration Request", integration_request_name
-        )
-        data = loads(integration_request.data)
-
-        mpesa_settings = data["mpesa_settings"]
-        transaction_id = data["transaction_id"]
-        remarks = data["remarks"]
-        queue_timeout_url = data["queue_timeout_url"]
-        result_url = data["result_url"]
-
-        settings = frappe.get_doc("Mpesa Settings", mpesa_settings)
-
-        # Initialize Mpesa Connector
         connector = MpesaConnector(
             env="production" if not settings.sandbox else "sandbox",
             app_key=settings.consumer_key,
@@ -533,16 +494,16 @@ def process_transaction_status(integration_request_name):
             integration_request.status = "Completed"
             integration_request.output = dumps(response)
             integration_request.save(ignore_permissions=True)
-            frappe.db.commit()
+            frappe.db.commit()  # nosegrep
 
-            frappe.publish_realtime(
-                event="mpesa_transaction_status",
-                message={
-                    "status": "success",
-                    "message": f"Transaction Status: {response.get('ResponseDescription')}",
-                },
-                user=frappe.session.user,
-            )
+            return {
+                "status": "success",
+                "message": response.get(
+                    "ResponseDescription", "Transaction status check completed"
+                ),
+                "data": response,
+            }
+
         else:
             error_msg = f"{response.get('errorCode', 'Unknown')}: {response.get('errorMessage', 'Unknown error')}"
             integration_request.status = "Failed"
@@ -550,21 +511,14 @@ def process_transaction_status(integration_request_name):
             integration_request.save(ignore_permissions=True)
             frappe.db.commit()
 
-            frappe.publish_realtime(
-                event="mpesa_transaction_status",
-                message={"status": "error", "message": error_msg},
-                user=frappe.session.user,
-            )
+            return {"status": "error", "message": error_msg}
 
     except Exception as e:
-        integration_request.status = "Failed"
-        integration_request.output = str(e)
-        integration_request.save(ignore_permissions=True)
-        frappe.db.commit()
+        if "integration_request" in locals():
+            integration_request.status = "Failed"
+            integration_request.output = str(e)
+            integration_request.save(ignore_permissions=True)
+            frappe.db.commit()  # nosegrep
 
-        frappe.log_error(title="Mpesa Transaction Status Process Error", message=str(e))
-        frappe.publish_realtime(
-            event="mpesa_transaction_status",
-            message={"status": "error", "message": f"Error checking status: {str(e)}"},
-            user=frappe.session.user,
-        )
+        frappe.log_error(title="Mpesa Transaction Status Error", message=str(e))
+        return {"status": "error", "message": str(e)}


### PR DESCRIPTION
### Summary
This PR enhances the Mpesa **Transaction Status** flow by properly handling and surfacing **asynchronous callback results** from Safaricom instead of only returning the initial API request status.

Previously, the UI could only confirm that the transaction status request was successfully sent to Mpesa. With these changes, the system now also communicates the **actual outcome of the transaction** once the callback is received and processed.


### Key Changes
- Added robust handling for **Mpesa Transaction Status Result callbacks**
- Centralized callback processing logic with clear success, failure, and duplicate detection paths
- Persisted callback outcomes to `Integration Request` for traceability and auditing
- Introduced **realtime UI updates** using `frappe.publish_realtime` to notify when:
  - A transaction succeeds
  - A transaction fails
  - A duplicate transaction is detected
- Improved error handling and logging for easier debugging and operational visibility


### Why This Change?
Mpesa Transaction Status checks are **asynchronous by design**.  
A successful API request (`ResponseCode = 0`) only confirms that Safaricom accepted the request, **not** that the transaction itself succeeded.

This change:
- Processes the Mpesa callback response as the source of truth
- Makes final transaction outcomes visible to users and administrators
- Aligns the implementation with real-world Mpesa retry and callback behavior


https://github.com/user-attachments/assets/a4fe349b-9f7e-4403-a900-02de98f03005

