### PR TITLE
feat(transaction): optimize M-Pesa success callback and reconciliation

### DIFF
--- a/frappe_mpsa_payments/utils/utils.py
+++ b/frappe_mpsa_payments/utils/utils.py
@@ -169,6 +169,13 @@ def log_and_throw_error(err_msg, context=None):
 
 def handle_successful_transaction(request_doc, settings):
     """Handle actions for a successful transaction"""
+    if request_doc.get("reference_doctype") and request_doc.get("reference_name"):
+            frappe.get_doc(
+                request_doc.get("reference_doctype"), request_doc.get("reference_name")
+            ).run_method("on_payment_authorized", "Completed") 
+            set_mpesa_request_reconciled(request_doc)  
+            frappe.db.commit()
+
     if "erpnext" in frappe.get_installed_apps():
         if request_doc.reference_doctype == "Payment Request":
             payment_request = frappe.get_doc(
@@ -252,9 +259,14 @@ def handle_successful_transaction(request_doc, settings):
             event_booking = frappe.get_doc("Event Booking", request_doc.reference_name)
             event_booking.submit()
             event_payment = frappe.get_doc("Event Payment", {"reference_docname": event_booking.name, "reference_doctype": "Event Booking"})
-            event_payment.payment_id = request_doc.transaction_id
-            event_payment.payment_received = 1
-            event_payment.save(ignore_permissions=True)
+            frappe.db.set_value(
+                "Event Payment",
+                event_payment.name,
+                {
+                    "payment_received": 1,
+                    "payment_id": request_doc.transaction_id
+                },
+            )
             set_mpesa_request_reconciled(request_doc)
         except Exception:
             log_and_throw_error("Event Booking Submission Error", request_doc.name)


### PR DESCRIPTION
Improve the reliability of payment processing by implementing direct DB updates and standardized hook execution.

- Trigger the 'on_payment_authorized' hook on referenced documents
  to initiate post-payment workflows.
- Mark M-Pesa requests as reconciled via 'frappe.db.set_value' to
  ensure an atomic state change.
- Bypass standard 'doc.save()' overhead for event payments to avoid
  permission issues and race conditions.
- Execute 'frappe.db.commit()' immediately after authorization to guarantee data persistence during external callbacks.