### PR TITLE
fix: remove _table_fieldnames override in MpesaPaymentReconciliation

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_payment_reconciliation/mpesa_payment_reconciliation.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_payment_reconciliation/mpesa_payment_reconciliation.py
@@ -6,9 +6,6 @@ from frappe.model.document import Document
 
 
 class MpesaPaymentReconciliation(Document):
-
-	_table_fieldnames = []
-
 	def save(self):
 		return
 	


### PR DESCRIPTION
Overriding _table_fieldnames as a list broke the boot process for non-admin users with User Permissions in v16. Removing it restores proper meta dict structure, ensuring get_all_children() and permission checks work correctly.