### PR TITLE
fix: add currency field to C2B register and backfill existing records

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/migrate.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/migrate.py
@@ -1,7 +1,7 @@
 import frappe
-from .patches.mpesa_custom_fields import create_custom_pos_fields
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
+from .patches.mpesa_custom_fields import create_custom_pos_fields
 
 MODULE = "Frappe Mpsa Payments"
 
@@ -122,7 +122,7 @@ def create_custom_erpnext_fields():
                 "options": "B2C Payment Disbursement",
             }
         ],
-        "Sales Invoice": [
+        "Sales Invoice": [  # noqa: F601
             {
                 "fieldname": "initiate_stk_push",
                 "label": "Initiate STK Push",
@@ -280,6 +280,14 @@ def create_custom_erpnext_fields():
                 "options": "Payment Entry",
                 "read_only": 1,
                 "insert_after": "submit_payment",
+            },
+            {
+                "fieldname": "currency",
+                "fieldtype": "Link",
+                "label": "Currency",
+                "options": "Currency",
+                "read_only": 1,
+                "insert_after": "mode_of_payment",
             },
         ],
         "Mpesa C2B Payment Register URL": [

--- a/frappe_mpsa_payments/frappe_mpsa_payments/patches/c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/patches/c2b_payment_register.py
@@ -1,0 +1,18 @@
+import frappe
+
+
+def execute():
+    c2b_payments = frappe.get_all(
+        "Mpesa C2B Payment Register",
+        fields=["name"],
+        filters={"currency": ""},
+    )
+
+    for payment in c2b_payments:
+        frappe.db.set_value(
+            "Mpesa C2B Payment Register",
+            payment.name,
+            "currency",
+            "KES",
+            update_modified=False,
+        )

--- a/frappe_mpsa_payments/patches.txt
+++ b/frappe_mpsa_payments/patches.txt
@@ -7,3 +7,4 @@
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 # frappe_mpsa_payments.frappe_mpsa_payments.patches.mpesa_custom_fields
+frappe_mpsa_payments.frappe_mpsa_payments.patches.c2b_payment_register


### PR DESCRIPTION
- Introduce a read-only Currency link field on Mpesa C2B Payment Register during custom field setup, and add a post-model-sync patch that backfills missing currency values to KES for existing records.