### PR TITLE
Feat/stk push for payment entry

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/payment_entry.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/payment_entry.py
@@ -6,6 +6,7 @@ import frappe.defaults
 from frappe import _, qb
 from frappe.utils import (
     flt,
+    get_url_to_form,
     getdate,
     nowdate,
 )
@@ -630,21 +631,46 @@ def initiate_payment_entry_stk(payment_entry):
 
     phone_number = sanitize_mobile_number(phone_number)
 
-    # indempotency: to prevent resending an stk push if one is already in progress or already paid
-    existing = frappe.db.exists(
+    # Where the stkpush page should send the user once the payment is
+    # reconciled and the Payment Entry has been submitted.
+    redirect_to = get_url_to_form("Payment Entry", pe.name)
+
+    # idempotency so that never create a second prompt for a Payment Entry that is
+    # already paid or has a live/failed request. Instead, route the user back
+    # to the existing request's status page, where they can watch progress or
+    # retry (with an editable phone number) if it failed.
+    existing = frappe.db.get_value(
         "Mpesa Express Request",
         {
             "reference_doctype": "Payment Entry",
             "reference_name": pe.name,
-            "status": ["in", ["In Progress", "Completed"]],
+            "status": ["in", ["In Progress", "Completed", "Failed"]],
         },
+        ["name", "status", "route", "redirect_to"],
+        as_dict=True,
     )
 
     if existing:
-        status = frappe.db.get_value("Mpesa Express Request", existing, "status")
-        frappe.throw(
-            _("An STK Push for this Payment Entry is already {0}.").format(status)
-        )
+        if existing.status == "Completed":
+            frappe.throw(
+                _(
+                    "An M-Pesa payment for this Payment Entry has already been "
+                    "completed (request {0})."
+                ).format(existing.name)
+            )
+
+        # In Progress or Failed: refresh the request with the latest details
+        # from the Payment Entry so a retry from the status page uses them.
+        updates = {}
+        if not existing.redirect_to:
+            updates["redirect_to"] = redirect_to
+        if existing.status == "Failed":
+            updates["phone_number"] = phone_number
+            updates["amount"] = pe.paid_amount
+        if updates:
+            frappe.db.set_value("Mpesa Express Request", existing.name, updates)
+
+        return {"name": existing.name, "route": existing.route}
 
     request = frappe.get_doc(
         {
@@ -654,8 +680,9 @@ def initiate_payment_entry_stk(payment_entry):
             "reference_name": pe.name,
             "amount": pe.paid_amount,
             "phone_number": phone_number,
+            "redirect_to": redirect_to,
         }
     )
     request.insert(ignore_permissions=True)
-    request.submit()  # on_submit fires initiate_stk_push -> the prompt goes out
-    return request.name
+    request.submit()  # on_submit sends the stkpush
+    return {"name": request.name, "route": request.route}

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/payment_entry.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/payment_entry.py
@@ -1,5 +1,6 @@
 import ast
 import json
+
 import frappe
 import frappe.defaults
 from frappe import _, qb
@@ -10,8 +11,10 @@ from frappe.utils import (
 )
 
 from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import (
+    sanitize_mobile_number,
     submit_mpesa_payment,
 )
+from frappe_mpsa_payments.utils.doctype_names import MPESA_SETTINGS_DOCTYPE
 
 
 def create_payment_entry(
@@ -90,7 +93,7 @@ def create_payment_entry(
         company_currency,
         date,
         "for_selling" if payment_type == "Receive" else "for_buying",
-    ) 
+    )
     paid_amount, received_amount = set_paid_amount_and_received_amount(
         party_account_currency, bank, amount, payment_type, None, conversion_rate
     )
@@ -571,3 +574,88 @@ def process_mpesa_c2b_customer_credit():
     create_and_reconcile_payment_reconciliation(
         invoice_name, customer, company, payment_entries
     )
+
+
+@frappe.whitelist()
+def initiate_payment_entry_stk(payment_entry):
+    pe = frappe.get_doc("Payment Entry", payment_entry)
+    pe.check_permission("submit")
+
+    if pe.docstatus != 0:
+        frappe.throw(_("STK push can only be initiated on a draft Payment Entry."))
+
+    if pe.payment_type != "Receive" or pe.party_type != "Customer":
+        frappe.throw(_("STK Push is only supported for incoming customer payments."))
+
+    if not pe.get("custom_payment_gateway_account"):
+        frappe.throw(_("Set the Payment Gateway Account before initiating STK Push."))
+
+    if pe.difference_amount:
+        frappe.throw(
+            _(
+                "Difference Amount must be zero before initiating an STK Push, otherwise "
+                "the Payment Entry will not be submittable once the payment is received."
+            )
+        )
+
+    # Get the mpesa settings record from the gateway account, and confirm it is an Mpesa gateway
+    payment_gateway = frappe.db.get_value(
+        "Payment Gateway Account", pe.custom_payment_gateway_account, "payment_gateway"
+    )
+
+    gateway_meta = frappe.db.get_value(
+        "Payment Gateway",
+        payment_gateway,
+        ["gateway_settings", "gateway_controller"],
+        as_dict=True,
+    )
+    if not gateway_meta or not gateway_meta.gateway_controller:
+        frappe.throw(
+            _("Could not resolve Mpesa Settings from that Payment Gateway Account.")
+        )
+
+    if gateway_meta.gateway_settings != MPESA_SETTINGS_DOCTYPE:
+        frappe.throw(
+            _("The selected Payment Gateway Account is not configured for M-Pesa.")
+        )
+
+    settings = gateway_meta.gateway_controller
+
+    phone_number = pe.get("custom_mpesa_phone_number")
+    if not phone_number and pe.party:
+        phone_number = frappe.db.get_value("Customer", pe.party, "mobile_no")
+
+    if not phone_number:
+        frappe.throw(_("No M-Pesa phone number on the Payment Entry or the Customer."))
+
+    phone_number = sanitize_mobile_number(phone_number)
+
+    # indempotency: to prevent resending an stk push if one is already in progress or already paid
+    existing = frappe.db.exists(
+        "Mpesa Express Request",
+        {
+            "reference_doctype": "Payment Entry",
+            "reference_name": pe.name,
+            "status": ["in", ["In Progress", "Completed"]],
+        },
+    )
+
+    if existing:
+        status = frappe.db.get_value("Mpesa Express Request", existing, "status")
+        frappe.throw(
+            _("An STK Push for this Payment Entry is already {0}.").format(status)
+        )
+
+    request = frappe.get_doc(
+        {
+            "doctype": "Mpesa Express Request",
+            "settings": settings,
+            "reference_doctype": "Payment Entry",
+            "reference_name": pe.name,
+            "amount": pe.paid_amount,
+            "phone_number": phone_number,
+        }
+    )
+    request.insert(ignore_permissions=True)
+    request.submit()  # on_submit fires initiate_stk_push -> the prompt goes out
+    return request.name

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
@@ -159,6 +159,7 @@ class MpesaExpressRequest(Document):
 
     @frappe.whitelist()
     def reconcile_payment(self):
+        self.reload()
         settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, self.settings)
 
         if not self.is_reconciled:

--- a/frappe_mpsa_payments/frappe_mpsa_payments/patches/payment_entry_custom_fields.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/patches/payment_entry_custom_fields.py
@@ -1,0 +1,60 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+    create_payment_entry_mpesa_fields()
+
+
+def create_payment_entry_mpesa_fields():
+    custom_fields = {
+        "Payment Entry": [
+            {
+                "fieldname": "custom_mpesa_section",
+                "label": "M-Pesa STK Push",
+                "fieldtype": "Section Break",
+                "insert_after": "mode_of_payment",
+                "depends_on": "eval:doc.payment_type=='Receive' && doc.party_type=='Customer'",
+                "module": "Frappe Mpsa Payments",
+            },
+            {
+                "fieldname": "custom_payment_gateway_account",
+                "label": "Payment Gateway Account",
+                "fieldtype": "Link",
+                "options": "Payment Gateway Account",
+                "insert_after": "custom_mpesa_section",
+                "module": "Frappe Mpsa Payments",
+            },
+            {
+                "fieldname": "custom_payment_gateway",
+                "label": "Payment Gateway",
+                "fieldtype": "Link",
+                "options": "Payment Gateway",
+                "fetch_from": "custom_payment_gateway_account.payment_gateway",
+                "read_only": 1,
+                "insert_after": "custom_payment_gateway_account",
+                "module": "Frappe Mpsa Payments",
+            },
+            {
+                "fieldname": "custom_mpesa_column_break",
+                "fieldtype": "Column Break",
+                "insert_after": "custom_payment_gateway",
+                "module": "Frappe Mpsa Payments",
+            },
+            {
+                "fieldname": "custom_mpesa_phone_number",
+                "label": "M-Pesa Phone Number",
+                "fieldtype": "Data",
+                "insert_after": "custom_mpesa_column_break",
+                "module": "Frappe Mpsa Payments",
+            },
+            {
+                "fieldname": "custom_mpesa_receipt_number",
+                "label": "M-Pesa Receipt Number",
+                "fieldtype": "Data",
+                "read_only": 1,
+                "insert_after": "custom_mpesa_phone_number",
+                "module": "Frappe Mpsa Payments",
+            },
+        ]
+    }
+    create_custom_fields(custom_fields, update=True)

--- a/frappe_mpsa_payments/hooks.py
+++ b/frappe_mpsa_payments/hooks.py
@@ -61,6 +61,7 @@ doctype_js = {
     "Sales Invoice": "public/js/sales_invoice.js",
     "POS Invoice": "public/js/pos_invoice.js",
     "Payment Request": "public/js/payment_request.js",
+    "Payment Entry": "public/js/payment_entry.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/frappe_mpsa_payments/patches.txt
+++ b/frappe_mpsa_payments/patches.txt
@@ -8,3 +8,4 @@
 # Patches added in this section will be executed after doctypes are migrated
 # frappe_mpsa_payments.frappe_mpsa_payments.patches.mpesa_custom_fields
 frappe_mpsa_payments.frappe_mpsa_payments.patches.c2b_payment_register
+frappe_mpsa_payments.frappe_mpsa_payments.patches.payment_entry_custom_fields

--- a/frappe_mpsa_payments/public/js/payment_entry.js
+++ b/frappe_mpsa_payments/public/js/payment_entry.js
@@ -17,28 +17,10 @@ frappe.ui.form.on("Payment Entry", {
 					freeze: true,
 					freeze_message: __("Sending STK Push..."),
 					callback: (r) => {
-						if (!r.exc) {
-							frappe.show_alert({
-								message: __(
-									"STK Push sent. Ask the customer to enter their M-Pesa PIN."
-								),
-								indicator: "green",
-							});
-
-							const handler = (data) => {
-								if (
-									data.reference_doctype === "Payment Entry" &&
-									data.reference_name === frm.doc.name
-								) {
-									frappe.realtime.off("mpesa_stk_payment_completed", handler);
-									frappe.show_alert({
-										message: __("Payment received. Submitting..."),
-										indicator: "green",
-									});
-									frm.reload_doc();
-								}
-							};
-							frappe.realtime.on("mpesa_stk_payment_completed", handler);
+						if (!r.exc && r.message && r.message.route) {
+							// Redirect to the STK status page. It handles polling,
+							// retries, and returns once the Payment Entry is submitted.
+							window.location.href = r.message.route;
 						}
 					},
 				});

--- a/frappe_mpsa_payments/public/js/payment_entry.js
+++ b/frappe_mpsa_payments/public/js/payment_entry.js
@@ -1,0 +1,48 @@
+frappe.ui.form.on("Payment Entry", {
+	refresh(frm) {
+		if (
+			frm.doc.docstatus === 0 &&
+			!frm.is_new() &&
+			frm.doc.payment_type === "Receive" &&
+			frm.doc.party_type === "Customer" &&
+			frm.doc.custom_payment_gateway_account
+		) {
+			frm.add_custom_button(__("Initiate M-Pesa STK Push"), async () => {
+				if (frm.is_dirty()) {
+					await frm.save();
+				}
+				frappe.call({
+					method: "frappe_mpsa_payments.frappe_mpsa_payments.api.payment_entry.initiate_payment_entry_stk",
+					args: { payment_entry: frm.doc.name },
+					freeze: true,
+					freeze_message: __("Sending STK Push..."),
+					callback: (r) => {
+						if (!r.exc) {
+							frappe.show_alert({
+								message: __(
+									"STK Push sent. Ask the customer to enter their M-Pesa PIN."
+								),
+								indicator: "green",
+							});
+
+							const handler = (data) => {
+								if (
+									data.reference_doctype === "Payment Entry" &&
+									data.reference_name === frm.doc.name
+								) {
+									frappe.realtime.off("mpesa_stk_payment_completed", handler);
+									frappe.show_alert({
+										message: __("Payment received. Submitting..."),
+										indicator: "green",
+									});
+									frm.reload_doc();
+								}
+							};
+							frappe.realtime.on("mpesa_stk_payment_completed", handler);
+						}
+					},
+				});
+			});
+		}
+	},
+});

--- a/frappe_mpsa_payments/utils/utils.py
+++ b/frappe_mpsa_payments/utils/utils.py
@@ -289,6 +289,26 @@ def handle_successful_transaction(request_doc, settings):
                 log_and_throw_error(
                     "Sales Invoice Payment Update Error", request_doc.name
                 )
+        elif request_doc.reference_doctype == "Payment Entry":
+            payment_entry = frappe.get_doc("Payment Entry", request_doc.reference_name)
+            if payment_entry.docstatus == 0:
+                try:
+                    payment_entry.reference_no = request_doc.transaction_id
+                    payment_entry.custom_mpesa_receipt_number = (
+                        request_doc.transaction_id
+                    )
+                    payment_entry.reference_date = (
+                        frappe.utils.getdate(request_doc.transaction_date)
+                        if request_doc.transaction_date
+                        else frappe.utils.nowdate()
+                    )
+                    payment_entry.save(ignore_permissions=True)
+                    payment_entry.submit()
+                    set_mpesa_request_reconciled(request_doc)
+                except Exception:
+                    log_and_throw_error(
+                        "Payment Entry Submission Error", request_doc.name
+                    )
     if request_doc.reference_doctype == "Event Booking":
         try:
             frappe.flags.ignore_permissions = True

--- a/frappe_mpsa_payments/utils/utils.py
+++ b/frappe_mpsa_payments/utils/utils.py
@@ -169,6 +169,10 @@ def log_and_throw_error(err_msg, context=None):
 
 def handle_successful_transaction(request_doc, settings):
     """Handle actions for a successful transaction"""
+
+    if request_doc.reference_doctype == "Payment Entry" and not request_doc.transaction_id:
+        return
+
     if request_doc.get("reference_doctype") and request_doc.get("reference_name"):
         frappe.get_doc(
             request_doc.get("reference_doctype"), request_doc.get("reference_name")

--- a/frappe_mpsa_payments/www/mpesa/stkpush.py
+++ b/frappe_mpsa_payments/www/mpesa/stkpush.py
@@ -93,9 +93,16 @@ def retry_stkpush(name, phone_number):
 @frappe.whitelist()
 def check_payment_status(name):
     doc = frappe.get_doc("Mpesa Express Request", name)
+
+    # For Payment Entries, redirect only after reconciliation. This prevents
+    # a transaction status query from redirecting to a draft Payment Entry.
+    redirect_to = doc.redirect_to
+    if doc.reference_doctype == "Payment Entry" and not doc.is_reconciled:
+        redirect_to = None
+    
     return {
         "status": doc.status,
         "docstatus": doc.docstatus,
         "response_description": doc.response_description,
-        "redirect_to": doc.redirect_to,
+        "redirect_to": redirect_to,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.0.0,<17.0.0"
+frappe = ">=16.0.0,<17.0.0"
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0,<17.0.0"
+frappe = ">=15.0.0,<17.0.0"
 
 [build-system]
 requires = ["flit_core >=3.4,<4"]


### PR DESCRIPTION
This pull request introduces comprehensive support for initiating and reconciling M-Pesa STK Push payments directly from the `Payment Entry` doctype. It includes backend API logic, UI enhancements, automated field creation, and reconciliation logic to streamline the M-Pesa payment workflow for customer receipts.

**M-Pesa STK Push Integration for Payment Entry**

_Backend logic and validation:_

* Added the `initiate_payment_entry_stk` backend method to `payment_entry.py`, which validates the payment entry, ensures correct gateway configuration, sanitizes the phone number, checks for duplicate or in-progress requests, and creates/submits a new `Mpesa Express Request` for STK Push payments.
* Updated reconciliation logic in `mpesa_express_request.py` to reload the document before reconciling, ensuring the latest state is used.
* Enhanced the `handle_successful_transaction` function to submit and reconcile `Payment Entry` documents upon successful M-Pesa payment, including setting reference numbers and receipt fields. [[1]](diffhunk://#diff-d6a5d72939c905fe795212b12445d158f8d7392f56f1d91f5ea49681cb8a4af5R172-R175) [[2]](diffhunk://#diff-d6a5d72939c905fe795212b12445d158f8d7392f56f1d91f5ea49681cb8a4af5R296-R315)

_User interface enhancements:_

* Added a custom button to the `Payment Entry` form (via new `payment_entry.js`) that allows users to initiate an M-Pesa STK Push, handles user feedback, and listens for real-time payment completion events to automatically reload and submit the entry.
* Registered the new JS file for the `Payment Entry` doctype in `hooks.py`.

_Automated field creation and setup:_

* Introduced a patch (`payment_entry_custom_fields.py`) and registered it in `patches.txt` to automatically add all necessary custom fields (gateway account, phone number, receipt number, etc.) to the `Payment Entry` doctype for M-Pesa integration. [[1]](diffhunk://#diff-fb91d927da2f48fea5dde65005f852bd8d8a7e072b5980070dd3d684aa72761cR1-R60) [[2]](diffhunk://#diff-2327e57e8792328a2a4b69073ff139b3f0c04a0669d265ae403835945462a1bdR11)

**Other supporting changes:**

* Imported utility functions and constants required for the new logic, such as `sanitize_mobile_number` and `MPESA_SETTINGS_DOCTYPE`. [[1]](diffhunk://#diff-733315caebadfe6492623bbbae745c03d37b29f34042b5d33bb7b45168aa2bd7R3) [[2]](diffhunk://#diff-733315caebadfe6492623bbbae745c03d37b29f34042b5d33bb7b45168aa2bd7R14-R17)

These changes collectively enable a seamless, validated, and user-friendly experience for handling M-Pesa STK Push payments within the Payment Entry workflow.