### PR TITLE
Reordered the Mpesa section on payment entry for better ux

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/patches/payment_entry_custom_fields.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/patches/payment_entry_custom_fields.py
@@ -12,9 +12,10 @@ def create_payment_entry_mpesa_fields():
                 "fieldname": "custom_mpesa_section",
                 "label": "M-Pesa STK Push",
                 "fieldtype": "Section Break",
-                "insert_after": "mode_of_payment",
+                "insert_after": "cost_center",
                 "depends_on": "eval:doc.payment_type=='Receive' && doc.party_type=='Customer'",
                 "module": "Frappe Mpsa Payments",
+                "collapsible": 1,
             },
             {
                 "fieldname": "custom_payment_gateway_account",

--- a/frappe_mpsa_payments/patches.txt
+++ b/frappe_mpsa_payments/patches.txt
@@ -8,4 +8,4 @@
 # Patches added in this section will be executed after doctypes are migrated
 # frappe_mpsa_payments.frappe_mpsa_payments.patches.mpesa_custom_fields
 frappe_mpsa_payments.frappe_mpsa_payments.patches.c2b_payment_register
-frappe_mpsa_payments.frappe_mpsa_payments.patches.payment_entry_custom_fields
+frappe_mpsa_payments.frappe_mpsa_payments.patches.payment_entry_custom_fields # v16: mpesa-section update


### PR DESCRIPTION
This pull request updates the M-Pesa section in the Payment Entry form and clarifies the related patch entry. The main changes are:

**Payment Entry Form Custom Field Updates:**

* The `custom_mpesa_section` field in the Payment Entry form is now inserted after the `cost_center` field instead of `mode_of_payment`, and it has been made collapsible for better UI organization.