### PR TITLE
Pull Transactions

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -25,6 +25,7 @@ from ...utils.utils import (
 )
 from .mpesa_response_handler import (
     balance_query_on_success,
+    pull_transaction_on_error,
     pull_transaction_on_success,
     stk_push_on_success,
     transaction_status_on_success,
@@ -1051,13 +1052,17 @@ def pull_transactions(
         frappe.log_error(frappe.get_traceback(), "Mpesa Pull Transaction Error")
         return {"status": "error", "message": "Failed to pull transactions. Check Error Logs."}
 
-    frappe.enqueue(
-        "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.execute_pull_transactions",
-        queue="long",
-        timeout=600,
-        mpesa_settings=mpesa_settings,
-        payload=payload,
-    )
+    try:
+        frappe.enqueue(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.execute_pull_transactions",
+            queue="long",
+            timeout=600,
+            mpesa_settings=mpesa_settings,
+            payload=payload,
+        )
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "Mpesa Pull Transaction Error")
+        return {"status": "error", "message": "Failed to pull transactions. Check Error Logs."}
 
     return {
         "status": "success",
@@ -1079,6 +1084,7 @@ def execute_pull_transactions(mpesa_settings: str, payload: dict) -> None:
             method="POST",
             payload=payload,
             success_callback=pull_transaction_on_success,
+            error_callback=pull_transaction_on_error,
             request_description="Mpesa Pull Transaction",
             doctype=MPESA_SETTINGS_DOCTYPE,
             document_name=mpesa_settings,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -25,6 +25,7 @@ from ...utils.utils import (
 )
 from .mpesa_response_handler import (
     balance_query_on_success,
+    pull_transaction_on_success,
     stk_push_on_success,
     transaction_status_on_success,
 )
@@ -1030,18 +1031,10 @@ def pull_transactions(
     end_date: str,
     offset: int = 0,
 ) -> dict:
-    from datetime import datetime as _dt
-
-    from frappe_mpsa_payments.frappe_mpsa_payments.api.mpesa_response_handler import (
-        pull_transaction_on_success,
-    )
-    from frappe_mpsa_payments.frappe_mpsa_payments.api.process_request import (
-        process_request,
-    )
-    from frappe_mpsa_payments.utils.doctype_names import MPESA_SETTINGS_DOCTYPE
-
     def _fmt(dt_str: str) -> str:
-        return _dt.strptime(dt_str.strip(), "%Y-%m-%d %H:%M:%S").strftime("%Y%m%d%H%M%S")
+        return datetime.datetime.strptime(dt_str.strip(), "%Y-%m-%d %H:%M:%S").strftime(
+            "%Y%m%d%H%M%S"
+        )
 
     try:
         settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, mpesa_settings)
@@ -1054,7 +1047,7 @@ def pull_transactions(
             "OffSet": str(int(offset)),
         }
 
-        process_request(
+        result = process_request(
             endpoint="/pulltransactions/v1/query",
             settings_name=mpesa_settings,
             method="POST",
@@ -1065,7 +1058,17 @@ def pull_transactions(
             document_name=mpesa_settings,
         )
 
-        return {"status": "success", "message": "Pull request submitted. Importing transactions..."}
+        count = 0
+        if isinstance(result, dict):
+            raw = (result.get("Transactions") or {}).get("Transaction", [])
+            transactions = raw if isinstance(raw, list) else [raw] if raw else []
+            count = len(transactions)
+
+        return {
+            "status": "success",
+            "message": "Pull request submitted. Importing transactions...",
+            "count": count,
+        }
 
     except Exception:
         frappe.log_error(frappe.get_traceback(), "Mpesa Pull Transaction Error")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -1021,3 +1021,52 @@ def verify_transaction(**kwargs) -> None:
             ),
         },
     )
+
+
+@frappe.whitelist()
+def pull_transactions(
+    mpesa_settings: str,
+    start_date: str,
+    end_date: str,
+    offset: int = 0,
+) -> dict:
+    from datetime import datetime as _dt
+
+    from frappe_mpsa_payments.frappe_mpsa_payments.api.mpesa_response_handler import (
+        pull_transaction_on_success,
+    )
+    from frappe_mpsa_payments.frappe_mpsa_payments.api.process_request import (
+        process_request,
+    )
+    from frappe_mpsa_payments.utils.doctype_names import MPESA_SETTINGS_DOCTYPE
+
+    def _fmt(dt_str: str) -> str:
+        return _dt.strptime(dt_str.strip(), "%Y-%m-%d %H:%M:%S").strftime("%Y%m%d%H%M%S")
+
+    try:
+        settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, mpesa_settings)
+        shortcode = settings.till_number if settings.sandbox else settings.business_shortcode
+
+        payload = {
+            "ShortCode": shortcode,
+            "StartDate": _fmt(start_date),
+            "EndDate": _fmt(end_date),
+            "OffSet": str(int(offset)),
+        }
+
+        process_request(
+            endpoint="/pulltransactions/v1/query",
+            settings_name=mpesa_settings,
+            method="POST",
+            payload=payload,
+            success_callback=pull_transaction_on_success,
+            request_description="Mpesa Pull Transaction",
+            doctype=MPESA_SETTINGS_DOCTYPE,
+            document_name=mpesa_settings,
+        )
+
+        return {"status": "success", "message": "Pull request submitted. Importing transactions..."}
+
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "Mpesa Pull Transaction Error")
+        return {"status": "error", "message": "Failed to pull transactions. Check Error Logs."}

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -1047,7 +1047,33 @@ def pull_transactions(
             "OffSet": str(int(offset)),
         }
 
-        result = process_request(
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "Mpesa Pull Transaction Error")
+        return {"status": "error", "message": "Failed to pull transactions. Check Error Logs."}
+
+    frappe.enqueue(
+        "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.execute_pull_transactions",
+        queue="long",
+        timeout=600,
+        mpesa_settings=mpesa_settings,
+        payload=payload,
+    )
+
+    return {
+        "status": "success",
+        "message": "Pull request queued. Importing transactions in the background...",
+    }
+
+
+def execute_pull_transactions(mpesa_settings: str, payload: dict) -> None:
+    """Call Safaricom's pull transactions endpoint and process the results.
+
+    Runs in the background (enqueued by `pull_transactions`) since the
+    Safaricom call plus C2B record creation/reconciliation can take a while
+    and shouldn't hold up the whitelisted request/response cycle.
+    """
+    try:
+        process_request(
             endpoint="/pulltransactions/v1/query",
             settings_name=mpesa_settings,
             method="POST",
@@ -1057,19 +1083,15 @@ def pull_transactions(
             doctype=MPESA_SETTINGS_DOCTYPE,
             document_name=mpesa_settings,
         )
-
-        count = 0
-        if isinstance(result, dict):
-            raw = (result.get("Transactions") or {}).get("Transaction", [])
-            transactions = raw if isinstance(raw, list) else [raw] if raw else []
-            count = len(transactions)
-
-        return {
-            "status": "success",
-            "message": "Pull request submitted. Importing transactions...",
-            "count": count,
-        }
-
     except Exception:
         frappe.log_error(frappe.get_traceback(), "Mpesa Pull Transaction Error")
-        return {"status": "error", "message": "Failed to pull transactions. Check Error Logs."}
+        frappe.publish_realtime(
+            event="mpesa_pull_transaction_complete",
+            message={
+                "status": "error",
+                "title": "Pull Transaction Failed",
+                "message": "Failed to pull transactions. Check Error Logs.",
+                "count": 0,
+            },
+            user=frappe.session.user,
+        )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -1045,7 +1045,7 @@ def pull_transactions(
             "ShortCode": shortcode,
             "StartDate": _fmt(start_date),
             "EndDate": _fmt(end_date),
-            "OffSet": int(offset),
+            "OffSetValue": str(int(offset)),
         }
 
     except Exception:

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -1034,7 +1034,7 @@ def pull_transactions(
 ) -> dict:
     def _fmt(dt_str: str) -> str:
         return datetime.datetime.strptime(dt_str.strip(), "%Y-%m-%d %H:%M:%S").strftime(
-            "%Y%m%d%H%M%S"
+            "%Y-%m-%d %H:%M:%S"
         )
 
     try:

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -1045,7 +1045,7 @@ def pull_transactions(
             "ShortCode": shortcode,
             "StartDate": _fmt(start_date),
             "EndDate": _fmt(end_date),
-            "OffSet": str(int(offset)),
+            "OffSet": int(offset),
         }
 
     except Exception:

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -179,3 +179,20 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
         },
         user=owner,
     )
+
+
+def pull_transaction_on_error(response: dict, document_name: str, **kwargs) -> None:
+    frappe.log_error(
+        title="Mpesa Pull Transaction: Safaricom Error",
+        message=frappe.as_json(response),
+    )
+    frappe.publish_realtime(
+        event="mpesa_pull_transaction_complete",
+        message={
+            "status": "error",
+            "title": "Pull Transaction Failed",
+            "message": response.get("errorMessage", "Safaricom rejected the pull request. Check Error Logs."),
+            "count": 0,
+        },
+        user=frappe.session.user,
+    )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -1,7 +1,11 @@
 import frappe
 from frappe.utils import now_datetime
 
-from ...utils.doctype_names import MPESA_EXPRESS_REQUEST_DOCTYPE, MPESA_SETTINGS_DOCTYPE
+from ...utils.doctype_names import (
+    MPESA_C2B_PAYMENT_REGISTER_DOCTYPE,
+    MPESA_EXPRESS_REQUEST_DOCTYPE,
+    MPESA_SETTINGS_DOCTYPE,
+)
 from ...utils.utils import (
     handle_successful_transaction,
     log_and_throw_error,
@@ -102,56 +106,65 @@ def stk_push_on_success(
 
 
 def pull_transaction_on_success(response: dict, document_name: str, **kwargs) -> None:
-    from frappe_mpsa_payments.utils.doctype_names import (
-        MPESA_C2B_PAYMENT_REGISTER_DOCTYPE,
-        MPESA_SETTINGS_DOCTYPE,
-    )
-
     settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, kwargs.get("settings_name", document_name))
     shortcode = settings.till_number if settings.sandbox else settings.business_shortcode
 
     raw = response.get("Transactions", {}).get("Transaction", [])
     transactions = raw if isinstance(raw, list) else [raw]
 
-    created, skipped = 0, 0
+    created, skipped, failed = 0, 0, 0
 
     for txn in transactions:
-        transid = txn.get("TransactionID", "")
-        if not transid:
-            continue
+        try:
+            transid = txn.get("TransactionID", "")
+            if not transid:
+                frappe.log_error(
+                    title="Mpesa Pull Transaction: Missing TransactionID",
+                    message=f"Transaction payload missing TransactionID: {txn}",
+                )
+                skipped += 1
+                continue
 
-        if frappe.db.exists(MPESA_C2B_PAYMENT_REGISTER_DOCTYPE, {"transid": transid}):
+            if frappe.db.exists(MPESA_C2B_PAYMENT_REGISTER_DOCTYPE, {"transid": transid}):
+                frappe.log_error(
+                    title="Mpesa Pull Transaction: Duplicate Skipped",
+                    message=f"transid={transid} already exists in {MPESA_C2B_PAYMENT_REGISTER_DOCTYPE}",
+                )
+                skipped += 1
+                continue
+
+            full_name = txn.get("FullName", "")
+            name_parts = full_name.split(" ", 2)
+
+            doc = frappe.new_doc(MPESA_C2B_PAYMENT_REGISTER_DOCTYPE)
+            doc.transid = transid
+            doc.transtime = txn.get("TransactionDate", "")
+            doc.transamount = float(txn.get("TransactionAmount") or 0.0)
+            doc.msisdn = txn.get("CustomerMSISDN", "")
+            doc.businessshortcode = shortcode
+            doc.billrefnumber = txn.get("BillReferenceNumber", "")
+            doc.orgaccountbalance = txn.get("OrgAccountBalance", "")
+            doc.thirdpartytransid = txn.get("OriginatorConversationID", "")
+            doc.transactiontype = txn.get("ReasonType", "")
+            doc.full_name = full_name
+            doc.firstname = name_parts[0] if len(name_parts) > 0 else ""
+            doc.middlename = name_parts[1] if len(name_parts) > 1 else ""
+            doc.lastname = name_parts[2] if len(name_parts) > 2 else ""
+            doc.insert(ignore_permissions=True)
+
             frappe.log_error(
-                title="Mpesa Pull Transaction: Duplicate Skipped",
-                message=f"transid={transid} already exists in {MPESA_C2B_PAYMENT_REGISTER_DOCTYPE}",
+                title="Mpesa Pull Transaction: Record Created",
+                message=f"transid={transid}, doc={doc.name}, amount={doc.transamount}, msisdn={doc.msisdn}",
             )
-            skipped += 1
+            created += 1
+
+        except Exception:
+            failed += 1
+            frappe.log_error(
+                frappe.get_traceback(),
+                f"Mpesa Pull Transaction: Failed for transid={txn.get('TransactionID', '')}",
+            )
             continue
-
-        full_name = txn.get("FullName", "")
-        name_parts = full_name.split(" ", 2)
-
-        doc = frappe.new_doc(MPESA_C2B_PAYMENT_REGISTER_DOCTYPE)
-        doc.transid = transid
-        doc.transtime = txn.get("TransactionDate", "")
-        doc.transamount = float(txn.get("TransactionAmount") or 0.0)
-        doc.msisdn = txn.get("CustomerMSISDN", "")
-        doc.businessshortcode = shortcode
-        doc.billrefnumber = txn.get("BillReferenceNumber", "")
-        doc.orgaccountbalance = txn.get("OrgAccountBalance", "")
-        doc.thirdpartytransid = txn.get("OriginatorConversationID", "")
-        doc.transactiontype = txn.get("ReasonType", "")
-        doc.full_name = full_name
-        doc.firstname = name_parts[0] if len(name_parts) > 0 else ""
-        doc.middlename = name_parts[1] if len(name_parts) > 1 else ""
-        doc.lastname = name_parts[2] if len(name_parts) > 2 else ""
-        doc.insert(ignore_permissions=True)
-
-        frappe.log_error(
-            title="Mpesa Pull Transaction: Record Created",
-            message=f"transid={transid}, doc={doc.name}, amount={doc.transamount}, msisdn={doc.msisdn}",
-        )
-        created += 1
 
     frappe.db.commit()
 
@@ -161,7 +174,7 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
         message={
             "status": "success" if created > 0 or skipped == len(transactions) else "warning",
             "title": "Pull Transaction Complete",
-            "message": f"{created} record(s) imported, {skipped} duplicate(s) skipped.",
+            "message": f"{created} record(s) imported, {skipped} skipped, {failed} failed.",
             "count": created,
         },
         user=owner,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -129,6 +129,7 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
     transactions = _flatten_pull_transactions(response.get("Response", []))
 
     created, skipped, failed = 0, 0, 0
+    created_records = []
 
     for txn in transactions:
         try:
@@ -159,10 +160,12 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
             doc.transactiontype = txn.get("transactiontype", "")
             doc.insert(ignore_permissions=True)
 
-            frappe.log_error(
-                title="Mpesa Pull Transaction: Record Created",
-                message=f"transid={transid}, doc={doc.name}, amount={doc.transamount}, msisdn={doc.msisdn}",
-            )
+            created_records.append({
+                "transid": transid,
+                "doc": doc.name,
+                "amount": doc.transamount,
+                "msisdn": doc.msisdn,
+            })
             created += 1
 
         except Exception:
@@ -174,6 +177,12 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
             continue
 
     frappe.db.commit()
+
+    if created_records:
+        frappe.log_error(
+            title="Mpesa Pull Transaction: Records Created",
+            message=frappe.as_json(created_records),
+        )
 
     owner = frappe.session.user
     frappe.publish_realtime(

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -99,3 +99,70 @@ def stk_push_on_success(
             frappe.get_traceback(), f"STK Push Success Error for {document_name}"
         )
         raise
+
+
+def pull_transaction_on_success(response: dict, document_name: str, **kwargs) -> None:
+    from frappe_mpsa_payments.utils.doctype_names import (
+        MPESA_C2B_PAYMENT_REGISTER_DOCTYPE,
+        MPESA_SETTINGS_DOCTYPE,
+    )
+
+    settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, kwargs.get("settings_name", document_name))
+    shortcode = settings.till_number if settings.sandbox else settings.business_shortcode
+
+    raw = response.get("Transactions", {}).get("Transaction", [])
+    transactions = raw if isinstance(raw, list) else [raw]
+
+    created, skipped = 0, 0
+
+    for txn in transactions:
+        transid = txn.get("TransactionID", "")
+        if not transid:
+            continue
+
+        if frappe.db.exists(MPESA_C2B_PAYMENT_REGISTER_DOCTYPE, {"transid": transid}):
+            frappe.log_error(
+                title="Mpesa Pull Transaction: Duplicate Skipped",
+                message=f"transid={transid} already exists in {MPESA_C2B_PAYMENT_REGISTER_DOCTYPE}",
+            )
+            skipped += 1
+            continue
+
+        full_name = txn.get("FullName", "")
+        name_parts = full_name.split(" ", 2)
+
+        doc = frappe.new_doc(MPESA_C2B_PAYMENT_REGISTER_DOCTYPE)
+        doc.transid = transid
+        doc.transtime = txn.get("TransactionDate", "")
+        doc.transamount = float(txn.get("TransactionAmount") or 0.0)
+        doc.msisdn = txn.get("CustomerMSISDN", "")
+        doc.businessshortcode = shortcode
+        doc.billrefnumber = txn.get("BillReferenceNumber", "")
+        doc.orgaccountbalance = txn.get("OrgAccountBalance", "")
+        doc.thirdpartytransid = txn.get("OriginatorConversationID", "")
+        doc.transactiontype = txn.get("ReasonType", "")
+        doc.full_name = full_name
+        doc.firstname = name_parts[0] if len(name_parts) > 0 else ""
+        doc.middlename = name_parts[1] if len(name_parts) > 1 else ""
+        doc.lastname = name_parts[2] if len(name_parts) > 2 else ""
+        doc.insert(ignore_permissions=True)
+
+        frappe.log_error(
+            title="Mpesa Pull Transaction: Record Created",
+            message=f"transid={transid}, doc={doc.name}, amount={doc.transamount}, msisdn={doc.msisdn}",
+        )
+        created += 1
+
+    frappe.db.commit()
+
+    owner = frappe.session.user
+    frappe.publish_realtime(
+        event="mpesa_pull_transaction_complete",
+        message={
+            "status": "success" if created > 0 or skipped == len(transactions) else "warning",
+            "title": "Pull Transaction Complete",
+            "message": f"{created} record(s) imported, {skipped} duplicate(s) skipped.",
+            "count": created,
+        },
+        user=owner,
+    )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -105,22 +105,38 @@ def stk_push_on_success(
         raise
 
 
+def _flatten_pull_transactions(raw) -> list:
+    if isinstance(raw, dict):
+        return [raw]
+    if not isinstance(raw, list):
+        return []
+    flat = []
+    for item in raw:
+        if isinstance(item, list):
+            flat.extend(_flatten_pull_transactions(item))
+        elif isinstance(item, dict):
+            flat.append(item)
+    return flat
+
+
 def pull_transaction_on_success(response: dict, document_name: str, **kwargs) -> None:
     settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, kwargs.get("settings_name", document_name))
     shortcode = settings.till_number if settings.sandbox else settings.business_shortcode
 
-    raw = response.get("Transactions", {}).get("Transaction", [])
-    transactions = raw if isinstance(raw, list) else [raw]
+    # Safaricom's actual response nests one list of transaction dicts inside
+    # "Response" (confirmed via live sandbox test) - not the "Transactions.Transaction"
+    # shape assumed at plan time.
+    transactions = _flatten_pull_transactions(response.get("Response", []))
 
     created, skipped, failed = 0, 0, 0
 
     for txn in transactions:
         try:
-            transid = txn.get("TransactionID", "")
+            transid = txn.get("transactionId", "")
             if not transid:
                 frappe.log_error(
                     title="Mpesa Pull Transaction: Missing TransactionID",
-                    message=f"Transaction payload missing TransactionID: {txn}",
+                    message=f"Transaction payload missing transactionId: {txn}",
                 )
                 skipped += 1
                 continue
@@ -133,23 +149,14 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
                 skipped += 1
                 continue
 
-            full_name = txn.get("FullName", "")
-            name_parts = full_name.split(" ", 2)
-
             doc = frappe.new_doc(MPESA_C2B_PAYMENT_REGISTER_DOCTYPE)
             doc.transid = transid
-            doc.transtime = txn.get("TransactionDate", "")
-            doc.transamount = float(txn.get("TransactionAmount") or 0.0)
-            doc.msisdn = txn.get("CustomerMSISDN", "")
+            doc.transtime = txn.get("trxDate", "")
+            doc.transamount = float(txn.get("amount") or 0.0)
+            doc.msisdn = txn.get("msisdn", "")
             doc.businessshortcode = shortcode
-            doc.billrefnumber = txn.get("BillReferenceNumber", "")
-            doc.orgaccountbalance = txn.get("OrgAccountBalance", "")
-            doc.thirdpartytransid = txn.get("OriginatorConversationID", "")
-            doc.transactiontype = txn.get("ReasonType", "")
-            doc.full_name = full_name
-            doc.firstname = name_parts[0] if len(name_parts) > 0 else ""
-            doc.middlename = name_parts[1] if len(name_parts) > 1 else ""
-            doc.lastname = name_parts[2] if len(name_parts) > 2 else ""
+            doc.billrefnumber = txn.get("billreference", "")
+            doc.transactiontype = txn.get("transactiontype", "")
             doc.insert(ignore_permissions=True)
 
             frappe.log_error(
@@ -162,7 +169,7 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
             failed += 1
             frappe.log_error(
                 frappe.get_traceback(),
-                f"Mpesa Pull Transaction: Failed for transid={txn.get('TransactionID', '')}",
+                f"Mpesa Pull Transaction: Failed for transid={txn.get('transactionId', '')}",
             )
             continue
 

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
@@ -1,33 +1,39 @@
 frappe.listview_settings["Mpesa C2B Payment Register"] = {
 	onload: function (listview) {
-		// Register realtime listener
-		if (!listview._mpesa_realtime_registered) {
-			listview._mpesa_realtime_registered = true;
-
-			frappe.realtime.on("mpesa_transaction_status_update", (data) => {
-				frappe.hide_progress();
-
-				frappe.msgprint({
-					message: __(data.message),
-					title: __(data.title),
-					indicator:
-						data.status === "error"
-							? "red"
-							: data.status === "warning"
-							? "orange"
-							: "green",
-				});
-
-				if (data.document_name) {
-					frappe.show_alert({
-						message: __("View transaction: {0}", [data.document_name]),
-						indicator: "green",
-					});
-				}
-
-				listview.refresh();
-			});
+		// Always remove the previous listener before re-registering.
+		// The guard-on-instance approach fails on navigation because each
+		// page load creates a new listview object while old socket listeners
+		// from the previous instance persist on the global event bus.
+		if (window._mpesa_c2b_status_handler) {
+			frappe.realtime.off("mpesa_transaction_status_update", window._mpesa_c2b_status_handler);
 		}
+		window._mpesa_c2b_status_handler = (data) => {
+			frappe.hide_progress();
+			if (window._mpesa_c2b_status_timeout) {
+				clearTimeout(window._mpesa_c2b_status_timeout);
+				window._mpesa_c2b_status_timeout = null;
+			}
+			frappe.msgprint({
+				message: __(data.message),
+				title: __(data.title),
+				indicator:
+					data.status === "error"
+						? "red"
+						: data.status === "warning"
+						? "orange"
+						: "green",
+			});
+
+			if (data.document_name) {
+				frappe.show_alert({
+					message: __("View transaction: {0}", [data.document_name]),
+					indicator: "green",
+				});
+			}
+
+			listview.refresh();
+		};
+		frappe.realtime.on("mpesa_transaction_status_update", window._mpesa_c2b_status_handler);
 		// Add a custom button to the page actions (top bar)
 		listview.page.add_inner_button(__("Check Transaction Status"), function () {
 			frappe.prompt(
@@ -96,6 +102,13 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 												100,
 												__("Waiting for M-Pesa callback...")
 											);
+											window._mpesa_c2b_status_timeout = setTimeout(() => {
+												frappe.hide_progress();
+												frappe.show_alert({
+													message: __("No callback received from M-Pesa. Check Error Logs."),
+													indicator: "orange",
+												});
+											}, 60000);
 										}
 									}
 								},

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -58,7 +58,12 @@ frappe.ui.form.on("Mpesa Settings", {
 			frappe.msgprint({
 				message: __(data.message),
 				title: __(data.title),
-				indicator: data.status === "error" ? "red" : "green",
+				indicator:
+					data.status === "error"
+						? "red"
+						: data.status === "warning"
+						? "orange"
+						: "green",
 			});
 		};
 		frappe.realtime.on("mpesa_pull_transaction_complete", frm._mpesa_pull_handler);

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -44,6 +44,24 @@ frappe.ui.form.on("Mpesa Settings", {
 			}
 		};
 		frappe.realtime.on("mpesa_transaction_status_update", frm._mpesa_status_handler);
+
+		// Pull transaction completion listener — same off/on pattern
+		if (frm._mpesa_pull_handler) {
+			frappe.realtime.off("mpesa_pull_transaction_complete", frm._mpesa_pull_handler);
+		}
+		frm._mpesa_pull_handler = (data) => {
+			frappe.hide_progress();
+			if (frm._mpesa_pull_timeout) {
+				clearTimeout(frm._mpesa_pull_timeout);
+				frm._mpesa_pull_timeout = null;
+			}
+			frappe.msgprint({
+				message: __(data.message),
+				title: __(data.title),
+				indicator: data.status === "error" ? "red" : "green",
+			});
+		};
+		frappe.realtime.on("mpesa_pull_transaction_complete", frm._mpesa_pull_handler);
 	},
 
 	get_account_balance: function (frm) {
@@ -140,6 +158,129 @@ frappe.ui.form.on("Mpesa Settings", {
 			},
 			__("Transaction Status Query"),
 			__("Submit")
+		);
+	},
+
+	register_pull_transaction: function (frm) {
+		if (!frm.doc.pull_transaction_nominated_number) {
+			frappe.throw(__("Please set the Pull Transaction Nominated Number first."));
+			return;
+		}
+		frappe.confirm(
+			__("Register nominated number {0} with Safaricom for Pull Transaction?", [
+				frm.doc.pull_transaction_nominated_number,
+			]),
+			() => {
+				frappe.call({
+					method: "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.register_pull_transaction",
+					args: { mpesa_settings: frm.doc.name },
+					freeze: true,
+					freeze_message: __("Registering with Safaricom..."),
+					callback: (r) => {
+						if (r.message && r.message.status === "success") {
+							frappe.show_alert({
+								message: __("Pull Transaction registered successfully."),
+								indicator: "green",
+							});
+						} else {
+							frappe.msgprint({
+								message: __(
+									r.message?.message || __("Registration failed. Check Error Logs.")
+								),
+								title: __("Registration Error"),
+								indicator: "red",
+							});
+						}
+					},
+					error: (err) => {
+						frappe.msgprint({
+							message: __("An error occurred: {0}", [err.message || "Unknown error"]),
+							title: __("Error"),
+							indicator: "red",
+						});
+					},
+				});
+			}
+		);
+	},
+
+	pull_transactions: function (frm) {
+		if (!frm.doc.pull_transaction_nominated_number) {
+			frappe.throw(
+				__("Please set the Pull Transaction Nominated Number and register before pulling.")
+			);
+			return;
+		}
+
+		frappe.prompt(
+			[
+				{
+					label: __("Start Date"),
+					fieldname: "start_date",
+					fieldtype: "Datetime",
+					reqd: 1,
+				},
+				{
+					label: __("End Date"),
+					fieldname: "end_date",
+					fieldtype: "Datetime",
+					reqd: 1,
+				},
+				{
+					label: __("Offset"),
+					fieldname: "offset",
+					fieldtype: "Int",
+					default: 0,
+					description: __("Page offset for pagination (0 = first page)"),
+				},
+			],
+			(values) => {
+				frappe.call({
+					method: "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.pull_transactions",
+					args: {
+						mpesa_settings: frm.doc.name,
+						start_date: values.start_date,
+						end_date: values.end_date,
+						offset: values.offset || 0,
+					},
+					freeze: true,
+					freeze_message: __("Pulling transactions from M-Pesa..."),
+					callback: (r) => {
+						if (r.message) {
+							if (r.message.status === "error") {
+								frappe.msgprint({
+									message: __(r.message.message),
+									title: __("Error"),
+									indicator: "red",
+								});
+							} else {
+								frappe.show_progress(
+									__("Processing"),
+									50,
+									100,
+									__("Importing transactions...")
+								);
+								frm._mpesa_pull_timeout = setTimeout(() => {
+									frappe.hide_progress();
+									frappe.show_alert({
+										message: __("Import is taking longer than expected. Check Error Logs."),
+										indicator: "orange",
+									});
+								}, 60000);
+							}
+						}
+					},
+					error: (err) => {
+						frappe.msgprint({
+							message: __("An error occurred: {0}", [err.message || "Unknown error"]),
+							title: __("Error"),
+							indicator: "red",
+						});
+					},
+				});
+			},
+			__("Pull Transactions"),
+			__("Pull")
 		);
 	},
 });

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -67,6 +67,17 @@ frappe.ui.form.on("Mpesa Settings", {
 			});
 		};
 		frappe.realtime.on("mpesa_pull_transaction_complete", frm._mpesa_pull_handler);
+
+		frm.add_custom_button(
+			__("Register Pull Transaction"),
+			() => frm.events.register_pull_transaction_action(frm),
+			__("Pull Transaction")
+		);
+		frm.add_custom_button(
+			__("Pull Transactions"),
+			() => frm.events.pull_transactions_action(frm),
+			__("Pull Transaction")
+		);
 	},
 
 	get_account_balance: function (frm) {
@@ -166,7 +177,7 @@ frappe.ui.form.on("Mpesa Settings", {
 		);
 	},
 
-	register_pull_transaction: function (frm) {
+	register_pull_transaction_action: function (frm) {
 		if (!frm.doc.pull_transaction_nominated_number) {
 			frappe.throw(__("Please set the Pull Transaction Nominated Number first."));
 			return;
@@ -209,7 +220,7 @@ frappe.ui.form.on("Mpesa Settings", {
 		);
 	},
 
-	pull_transactions: function (frm) {
+	pull_transactions_action: function (frm) {
 		if (!frm.doc.pull_transaction_nominated_number) {
 			frappe.throw(
 				__("Please set the Pull Transaction Nominated Number and register before pulling.")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -14,7 +14,38 @@ frappe.ui.form.on("Mpesa Settings", {
 			frm.reload_doc();
 			frm.events.setup_account_balance_html(frm);
 		});
+
+		// Register the transaction status listener once per form load,
+		// removing any prior instance first so clicks never stack listeners.
+		if (frm._mpesa_status_handler) {
+			frappe.realtime.off("mpesa_transaction_status_update", frm._mpesa_status_handler);
+		}
+		frm._mpesa_status_handler = (data) => {
+			frappe.hide_progress();
+			if (frm._mpesa_status_timeout) {
+				clearTimeout(frm._mpesa_status_timeout);
+				frm._mpesa_status_timeout = null;
+			}
+			frappe.msgprint({
+				message: __(data.message),
+				title: __(data.title),
+				indicator:
+					data.status === "error"
+						? "red"
+						: data.status === "warning"
+						? "orange"
+						: "green",
+			});
+			if (data.document_name) {
+				frappe.show_alert({
+					message: __("View transaction: {0}", [data.document_name]),
+					indicator: "green",
+				});
+			}
+		};
+		frappe.realtime.on("mpesa_transaction_status_update", frm._mpesa_status_handler);
 	},
+
 	get_account_balance: function (frm) {
 		if (!frm.doc.initiator_name && !frm.doc.security_credential) {
 			frappe.throw(__("Please set the initiator name and the security credential"));
@@ -41,28 +72,6 @@ frappe.ui.form.on("Mpesa Settings", {
 			frappe.throw(__("Please set the initiator name and the security credential"));
 			return;
 		}
-
-		frappe.realtime.on("mpesa_transaction_status_update", (data) => {
-			frappe.hide_progress();
-
-			frappe.msgprint({
-				message: __(data.message),
-				title: __(data.title),
-				indicator:
-					data.status === "error"
-						? "red"
-						: data.status === "warning"
-						? "orange"
-						: "green",
-			});
-
-			if (data.document_name) {
-				frappe.show_alert({
-					message: __("View transaction: {0}", [data.document_name]),
-					indicator: "green",
-				});
-			}
-		});
 
 		frappe.prompt(
 			[
@@ -106,6 +115,14 @@ frappe.ui.form.on("Mpesa Settings", {
 									100,
 									__("Waiting for M-Pesa callback...")
 								);
+								// Auto-cancel progress if Safaricom never calls back
+								frm._mpesa_status_timeout = setTimeout(() => {
+									frappe.hide_progress();
+									frappe.show_alert({
+										message: __("No callback received from M-Pesa. Check Error Logs."),
+										indicator: "orange",
+									});
+								}, 60000);
 							}
 						}
 					},

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -232,7 +232,7 @@ frappe.ui.form.on("Mpesa Settings", {
 		const PULL_WINDOW_HOURS = 48;
 
 		const render_date_range_display = () => {
-			const end_value = d.get_value("end_date") || moment().format(DATE_FORMAT);
+			const end_value = d.get_value("end_date") || frappe.datetime.now_datetime();
 			const end_moment = moment(end_value, DATE_FORMAT);
 			const start_moment = end_moment.clone().subtract(PULL_WINDOW_HOURS, "hours");
 			d.fields_dict.date_range_display.$wrapper.html(
@@ -251,7 +251,7 @@ frappe.ui.form.on("Mpesa Settings", {
 					fieldname: "end_date",
 					fieldtype: "Datetime",
 					reqd: 1,
-					default: moment().format(DATE_FORMAT),
+					default: frappe.datetime.now_datetime(),
 					onchange: () => render_date_range_display(),
 				},
 				{

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -228,19 +228,35 @@ frappe.ui.form.on("Mpesa Settings", {
 			return;
 		}
 
-		frappe.prompt(
-			[
-				{
-					label: __("Start Date"),
-					fieldname: "start_date",
-					fieldtype: "Datetime",
-					reqd: 1,
-				},
+		const DATE_FORMAT = "YYYY-MM-DD HH:mm:ss";
+		const PULL_WINDOW_HOURS = 48;
+
+		const render_date_range_display = () => {
+			const end_value = d.get_value("end_date") || moment().format(DATE_FORMAT);
+			const end_moment = moment(end_value, DATE_FORMAT);
+			const start_moment = end_moment.clone().subtract(PULL_WINDOW_HOURS, "hours");
+			d.fields_dict.date_range_display.$wrapper.html(
+				`<p>${__("Pulling transactions from {0} to {1}", [
+					`<b>${start_moment.format(DATE_FORMAT)}</b>`,
+					`<b>${end_moment.format(DATE_FORMAT)}</b>`,
+				])}</p>`
+			);
+		};
+
+		const d = new frappe.ui.Dialog({
+			title: __("Pull Transactions"),
+			fields: [
 				{
 					label: __("End Date"),
 					fieldname: "end_date",
 					fieldtype: "Datetime",
 					reqd: 1,
+					default: moment().format(DATE_FORMAT),
+					onchange: () => render_date_range_display(),
+				},
+				{
+					fieldname: "date_range_display",
+					fieldtype: "HTML",
 				},
 				{
 					label: __("Offset"),
@@ -250,12 +266,19 @@ frappe.ui.form.on("Mpesa Settings", {
 					description: __("Page offset for pagination (0 = first page)"),
 				},
 			],
-			(values) => {
+			primary_action_label: __("Pull"),
+			primary_action: (values) => {
+				const end_moment = moment(values.end_date, DATE_FORMAT);
+				const start_date = end_moment
+					.clone()
+					.subtract(PULL_WINDOW_HOURS, "hours")
+					.format(DATE_FORMAT);
+
 				frappe.call({
 					method: "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.pull_transactions",
 					args: {
 						mpesa_settings: frm.doc.name,
-						start_date: values.start_date,
+						start_date: start_date,
 						end_date: values.end_date,
 						offset: values.offset || 0,
 					},
@@ -294,9 +317,12 @@ frappe.ui.form.on("Mpesa Settings", {
 						});
 					},
 				});
+
+				d.hide();
 			},
-			__("Pull Transactions"),
-			__("Pull")
-		);
+		});
+
+		d.show();
+		render_date_range_display();
 	},
 });

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -31,6 +31,9 @@
   "transaction_limit",
   "initiator_name",
   "initiator_password",
+  "pull_transaction_nominated_number",
+  "register_pull_transaction",
+  "pull_transactions",
   "balance_details_section",
   "utility_account",
   "working_account",
@@ -293,10 +296,26 @@
    "fieldname": "submit_b2c_accounting_entries",
    "fieldtype": "Check",
    "label": "Submit B2C Accounting Entries"
+  },
+  {
+   "description": "Phone number nominated for Pull Transaction API (format: 2547XXXXXXXX)",
+   "fieldname": "pull_transaction_nominated_number",
+   "fieldtype": "Data",
+   "label": "Pull Transaction Nominated Number"
+  },
+  {
+   "fieldname": "register_pull_transaction",
+   "fieldtype": "Button",
+   "label": "Register Pull Transaction"
+  },
+  {
+   "fieldname": "pull_transactions",
+   "fieldtype": "Button",
+   "label": "Pull Transactions"
   }
  ],
  "links": [],
- "modified": "2025-06-16 16:50:41.648423",
+ "modified": "2026-07-04 19:45:00.000000",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -32,8 +32,6 @@
   "initiator_name",
   "initiator_password",
   "pull_transaction_nominated_number",
-  "register_pull_transaction",
-  "pull_transactions",
   "balance_details_section",
   "utility_account",
   "working_account",
@@ -302,20 +300,10 @@
    "fieldname": "pull_transaction_nominated_number",
    "fieldtype": "Data",
    "label": "Pull Transaction Nominated Number"
-  },
-  {
-   "fieldname": "register_pull_transaction",
-   "fieldtype": "Button",
-   "label": "Register Pull Transaction"
-  },
-  {
-   "fieldname": "pull_transactions",
-   "fieldtype": "Button",
-   "label": "Pull Transactions"
   }
  ],
  "links": [],
- "modified": "2026-07-04 19:45:00.000000",
+ "modified": "2026-07-06 07:56:00.000000",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -297,7 +297,7 @@
    "label": "Submit B2C Accounting Entries"
   },
   {
-   "description": "Phone number nominated for Pull Transaction API (format: 2547XXXXXXXX)",
+   "description": "Phone number nominated for Pull Transaction API (format: 254XXXXXXXXX — 254 followed by 9 digits)",
    "fieldname": "pull_transaction_nominated_number",
    "fieldtype": "Data",
    "label": "Pull Transaction Nominated Number"
@@ -310,7 +310,7 @@
   }
  ],
  "links": [],
- "modified": "2026-07-06 08:00:00.000000",
+ "modified": "2026-07-06 09:26:00.000000",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -32,7 +32,7 @@
   "initiator_name",
   "initiator_password",
   "pull_transaction_nominated_number",
-  "enable_daily_pull_transactions",
+  "enable_hourly_pull_transactions",
   "balance_details_section",
   "utility_account",
   "working_account",
@@ -303,14 +303,14 @@
    "label": "Pull Transaction Nominated Number"
   },
   {
-   "fieldname": "enable_daily_pull_transactions",
+   "fieldname": "enable_hourly_pull_transactions",
    "fieldtype": "Check",
-   "label": "Enable Daily Pull Transactions",
-   "description": "If checked, automatically pulls transactions for the last 24 hours once a day."
+   "label": "Enable Hourly Pull Transactions",
+   "description": "If checked, automatically pulls transactions for the last 2 hours once every hour."
   }
  ],
  "links": [],
- "modified": "2026-07-06 09:26:00.000000",
+ "modified": "2026-07-06 10:15:00.000000",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -32,6 +32,7 @@
   "initiator_name",
   "initiator_password",
   "pull_transaction_nominated_number",
+  "enable_daily_pull_transactions",
   "balance_details_section",
   "utility_account",
   "working_account",
@@ -300,10 +301,16 @@
    "fieldname": "pull_transaction_nominated_number",
    "fieldtype": "Data",
    "label": "Pull Transaction Nominated Number"
+  },
+  {
+   "fieldname": "enable_daily_pull_transactions",
+   "fieldtype": "Check",
+   "label": "Enable Daily Pull Transactions",
+   "description": "If checked, automatically pulls transactions for the last 24 hours once a day."
   }
  ],
  "links": [],
- "modified": "2026-07-06 07:56:00.000000",
+ "modified": "2026-07-06 08:00:00.000000",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "Mpesa Settings",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -534,3 +534,80 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
 
         frappe.log_error(title="Mpesa Transaction Status Error", message=str(e))
         return {"status": "error", "message": str(e)}
+
+
+@frappe.whitelist()
+def register_pull_transaction(mpesa_settings: str) -> dict:
+    import requests as _requests
+
+    from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import get_token
+    from frappe_mpsa_payments.utils.utils import build_callback_url
+
+    settings = frappe.get_doc("Mpesa Settings", mpesa_settings)
+
+    if not settings.pull_transaction_nominated_number:
+        frappe.throw(_("Pull Transaction Nominated Number is required."))
+
+    base_url = (
+        "https://sandbox.safaricom.co.ke"
+        if settings.sandbox
+        else "https://api.safaricom.co.ke"
+    )
+    token = get_token(
+        app_key=settings.consumer_key,
+        app_secret=settings.get_password("consumer_secret"),
+        base_url=base_url,
+    )
+    shortcode = (
+        settings.till_number if settings.sandbox else settings.business_shortcode
+    )
+    callback_url = build_callback_url(
+        "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.pull_transaction_callback"
+    )
+
+    payload = {
+        "ShortCode": shortcode,
+        "RequestType": "Pull",
+        "NominatedNumber": settings.pull_transaction_nominated_number,
+        "CallBackURL": callback_url,
+    }
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        resp = _requests.post(
+            f"{base_url}/pulltransactions/v1/register",
+            headers=headers,
+            json=payload,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        frappe.log_error(title="Mpesa Pull Transaction Registration Error", message=str(e))
+        return {"status": "error", "message": str(e)}
+
+    if data.get("ResponseCode") == "0":
+        return {
+            "status": "success",
+            "message": data.get("ResponseDescription", "Registered successfully"),
+        }
+
+    frappe.log_error(
+        title="Mpesa Pull Transaction Registration Error", message=str(data)
+    )
+    return {
+        "status": "error",
+        "message": data.get("ResponseDescription", "Registration failed"),
+    }
+
+
+@frappe.whitelist(allow_guest=True)
+def pull_transaction_callback(**kwargs) -> dict:
+    frappe.log_error(
+        title="Mpesa Pull Transaction Callback",
+        message=frappe.as_json(kwargs),
+    )
+    return {"ResultCode": 0, "ResultDesc": "Accepted"}

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -3,6 +3,7 @@
 
 
 import base64
+import re
 from json import dumps, loads
 from typing import Any
 from urllib.parse import urlparse
@@ -548,35 +549,43 @@ def register_pull_transaction(mpesa_settings: str) -> dict:
     if not settings.pull_transaction_nominated_number:
         frappe.throw(_("Pull Transaction Nominated Number is required."))
 
+    if not re.match(r"^2547\d{8}$", settings.pull_transaction_nominated_number):
+        frappe.throw(
+            _(
+                "Pull Transaction Nominated Number must be in the format 2547XXXXXXXX (12 digits, starting with 2547)."
+            )
+        )
+
     base_url = (
         "https://sandbox.safaricom.co.ke"
         if settings.sandbox
         else "https://api.safaricom.co.ke"
     )
-    token = get_token(
-        app_key=settings.consumer_key,
-        app_secret=settings.get_password("consumer_secret"),
-        base_url=base_url,
-    )
-    shortcode = (
-        settings.till_number if settings.sandbox else settings.business_shortcode
-    )
-    callback_url = build_callback_url(
-        "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.pull_transaction_callback"
-    )
-
-    payload = {
-        "ShortCode": shortcode,
-        "RequestType": "Pull",
-        "NominatedNumber": settings.pull_transaction_nominated_number,
-        "CallBackURL": callback_url,
-    }
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
 
     try:
+        token = get_token(
+            app_key=settings.consumer_key,
+            app_secret=settings.get_password("consumer_secret"),
+            base_url=base_url,
+        )
+        shortcode = (
+            settings.till_number if settings.sandbox else settings.business_shortcode
+        )
+        callback_url = build_callback_url(
+            "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.pull_transaction_callback"
+        )
+
+        payload = {
+            "ShortCode": shortcode,
+            "RequestType": "Pull",
+            "NominatedNumber": settings.pull_transaction_nominated_number,
+            "CallBackURL": callback_url,
+        }
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
         resp = _requests.post(
             f"{base_url}/pulltransactions/v1/register",
             headers=headers,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -549,10 +549,10 @@ def register_pull_transaction(mpesa_settings: str) -> dict:
     if not settings.pull_transaction_nominated_number:
         frappe.throw(_("Pull Transaction Nominated Number is required."))
 
-    if not re.match(r"^2547\d{8}$", settings.pull_transaction_nominated_number):
+    if not re.match(r"^254\d{9}$", settings.pull_transaction_nominated_number):
         frappe.throw(
             _(
-                "Pull Transaction Nominated Number must be in the format 2547XXXXXXXX (12 digits, starting with 2547)."
+                "Pull Transaction Nominated Number must be in the format 254XXXXXXXXX (254 followed by 9 digits)."
             )
         )
 
@@ -598,10 +598,10 @@ def register_pull_transaction(mpesa_settings: str) -> dict:
         frappe.log_error(title="Mpesa Pull Transaction Registration Error", message=str(e))
         return {"status": "error", "message": str(e)}
 
-    if data.get("ResponseCode") == "0":
+    if data.get("Response Status") == "1000":
         return {
             "status": "success",
-            "message": data.get("ResponseDescription", "Registered successfully"),
+            "message": data.get("Response Description", "Registered successfully"),
         }
 
     frappe.log_error(
@@ -609,7 +609,7 @@ def register_pull_transaction(mpesa_settings: str) -> dict:
     )
     return {
         "status": "error",
-        "message": data.get("ResponseDescription", "Registration failed"),
+        "message": data.get("Response Description", "Registration failed"),
     }
 
 

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
@@ -277,7 +277,6 @@ class TestMpesaSettings(unittest.TestCase):
         pos_invoice.delete()
 
     def test_register_pull_transaction_missing_nominated_number(self):
-        """register_pull_transaction throws when nominated number not set."""
         from frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings import (
             register_pull_transaction,
         )
@@ -286,7 +285,6 @@ class TestMpesaSettings(unittest.TestCase):
             register_pull_transaction("_Test")
 
     def test_register_pull_transaction_success(self):
-        """register_pull_transaction returns success when Safaricom accepts."""
         from unittest.mock import MagicMock, patch
 
         from frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings import (
@@ -304,7 +302,10 @@ class TestMpesaSettings(unittest.TestCase):
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("requests.post", return_value=mock_response):
+        with patch(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.get_token",
+            return_value="test_token",
+        ), patch("requests.post", return_value=mock_response):
             result = register_pull_transaction("_Test")
 
         self.assertEqual(result["status"], "success")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
@@ -311,6 +311,95 @@ class TestMpesaSettings(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("Accept", result["message"])
 
+    def test_pull_transaction_on_success_creates_c2b_records(self):
+        """pull_transaction_on_success inserts C2B records from a pull response."""
+        from frappe_mpsa_payments.frappe_mpsa_payments.api.mpesa_response_handler import (
+            pull_transaction_on_success,
+        )
+
+        unique_txn_id = f"PULL{frappe.generate_hash()[:8].upper()}"
+        response = {
+            "ResponseCode": "0",
+            "ResponseDescription": "Accept the service request successfully.",
+            "Transactions": {
+                "Transaction": [
+                    {
+                        "TransactionID": unique_txn_id,
+                        "TransactionDate": "20230601120000",
+                        "CustomerMSISDN": "254712345678",
+                        "BillReferenceNumber": "TEST-REF-001",
+                        "OrgAccountBalance": "5000.00",
+                        "TransactionAmount": "250.00",
+                        "FullName": "Jane Doe",
+                        "ReasonType": "Pay Bill Online",
+                        "OriginatorConversationID": "test-conv-id-001",
+                    }
+                ]
+            },
+        }
+
+        pull_transaction_on_success(
+            response=response,
+            document_name="_Test",
+            settings_name="_Test",
+            integration_request=None,
+        )
+
+        exists = frappe.db.exists(
+            "Mpesa C2B Payment Register", {"transid": unique_txn_id}
+        )
+        self.assertTrue(exists)
+        frappe.db.delete("Mpesa C2B Payment Register", {"transid": unique_txn_id})
+
+    def test_pull_transaction_on_success_skips_duplicates(self):
+        """pull_transaction_on_success skips a transid that already exists."""
+        from frappe_mpsa_payments.frappe_mpsa_payments.api.mpesa_response_handler import (
+            pull_transaction_on_success,
+        )
+
+        unique_txn_id = f"DUP{frappe.generate_hash()[:8].upper()}"
+
+        # Pre-insert so it already exists
+        existing = frappe.get_doc({
+            "doctype": "Mpesa C2B Payment Register",
+            "transid": unique_txn_id,
+            "transamount": 100.0,
+            "msisdn": "254700000001",
+            "businessshortcode": "174379",
+        })
+        existing.insert(ignore_permissions=True)
+
+        response = {
+            "ResponseCode": "0",
+            "Transactions": {
+                "Transaction": {
+                    "TransactionID": unique_txn_id,
+                    "TransactionDate": "20230601120000",
+                    "CustomerMSISDN": "254712345678",
+                    "BillReferenceNumber": "",
+                    "OrgAccountBalance": "0.00",
+                    "TransactionAmount": "100.00",
+                    "FullName": "John Duplicate",
+                    "ReasonType": "Pay Bill Online",
+                    "OriginatorConversationID": "dup-conv-id",
+                }
+            },
+        }
+
+        # Should not raise; duplicate is silently skipped
+        pull_transaction_on_success(
+            response=response,
+            document_name="_Test",
+            settings_name="_Test",
+            integration_request=None,
+        )
+
+        count = frappe.db.count(
+            "Mpesa C2B Payment Register", {"transid": unique_txn_id}
+        )
+        self.assertEqual(count, 1)
+        frappe.db.delete("Mpesa C2B Payment Register", {"transid": unique_txn_id})
+
     def test_processing_of_only_one_succes_callback_payload(self):
         mpesa_account = frappe.db.get_value(
             "Payment Gateway Account",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
@@ -312,30 +312,32 @@ class TestMpesaSettings(unittest.TestCase):
         self.assertIn("Accept", result["message"])
 
     def test_pull_transaction_on_success_creates_c2b_records(self):
-        """pull_transaction_on_success inserts C2B records from a pull response."""
         from frappe_mpsa_payments.frappe_mpsa_payments.api.mpesa_response_handler import (
             pull_transaction_on_success,
         )
 
         unique_txn_id = f"PULL{frappe.generate_hash()[:8].upper()}"
         response = {
-            "ResponseCode": "0",
-            "ResponseDescription": "Accept the service request successfully.",
-            "Transactions": {
-                "Transaction": [
+            "ResponseCode": "1000",
+            "ResponseMessage": "Success",
+            "Response": [
+                [
                     {
-                        "TransactionID": unique_txn_id,
-                        "TransactionDate": "20230601120000",
-                        "CustomerMSISDN": "254712345678",
-                        "BillReferenceNumber": "TEST-REF-001",
-                        "OrgAccountBalance": "5000.00",
-                        "TransactionAmount": "250.00",
-                        "FullName": "Jane Doe",
-                        "ReasonType": "Pay Bill Online",
-                        "OriginatorConversationID": "test-conv-id-001",
+                        "transactionId": unique_txn_id,
+                        "trxDate": "2026-06-01T12:00:00+03:00",
+                        "msisdn": "254712345678",
+                        "sender": "MPESA",
+                        "transactiontype": "c2b-paybill-debi",
+                        "billreference": "TEST-REF-001",
+                        "amount": "250.00",
+                        "organizationname": "Safaricom Daraja 978",
                     }
                 ]
-            },
+            ],
+            "CurrentPage": 0,
+            "PageSize": 10,
+            "TotalPages": 1,
+            "TotalRecords": 1,
         }
 
         pull_transaction_on_success(
@@ -352,7 +354,6 @@ class TestMpesaSettings(unittest.TestCase):
         frappe.db.delete("Mpesa C2B Payment Register", {"transid": unique_txn_id})
 
     def test_pull_transaction_on_success_skips_duplicates(self):
-        """pull_transaction_on_success skips a transid that already exists."""
         from frappe_mpsa_payments.frappe_mpsa_payments.api.mpesa_response_handler import (
             pull_transaction_on_success,
         )
@@ -370,20 +371,21 @@ class TestMpesaSettings(unittest.TestCase):
         existing.insert(ignore_permissions=True)
 
         response = {
-            "ResponseCode": "0",
-            "Transactions": {
-                "Transaction": {
-                    "TransactionID": unique_txn_id,
-                    "TransactionDate": "20230601120000",
-                    "CustomerMSISDN": "254712345678",
-                    "BillReferenceNumber": "",
-                    "OrgAccountBalance": "0.00",
-                    "TransactionAmount": "100.00",
-                    "FullName": "John Duplicate",
-                    "ReasonType": "Pay Bill Online",
-                    "OriginatorConversationID": "dup-conv-id",
-                }
-            },
+            "ResponseCode": "1000",
+            "Response": [
+                [
+                    {
+                        "transactionId": unique_txn_id,
+                        "trxDate": "2026-06-01T12:00:00+03:00",
+                        "msisdn": "254712345678",
+                        "sender": "MPESA",
+                        "transactiontype": "c2b-paybill-debi",
+                        "billreference": "",
+                        "amount": "100.00",
+                        "organizationname": "Safaricom Daraja 978",
+                    }
+                ]
+            ],
         }
 
         # Should not raise; duplicate is silently skipped

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
@@ -276,6 +276,40 @@ class TestMpesaSettings(unittest.TestCase):
         pr.delete()
         pos_invoice.delete()
 
+    def test_register_pull_transaction_missing_nominated_number(self):
+        """register_pull_transaction throws when nominated number not set."""
+        from frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings import (
+            register_pull_transaction,
+        )
+        # _Test settings has no pull_transaction_nominated_number
+        with self.assertRaises(frappe.exceptions.ValidationError):
+            register_pull_transaction("_Test")
+
+    def test_register_pull_transaction_success(self):
+        """register_pull_transaction returns success when Safaricom accepts."""
+        from unittest.mock import MagicMock, patch
+
+        from frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings import (
+            register_pull_transaction,
+        )
+
+        frappe.db.set_value(
+            "Mpesa Settings", "_Test", "pull_transaction_nominated_number", "254712345678"
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ResponseCode": "0",
+            "ResponseDescription": "Accept the service request successfully.",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response):
+            result = register_pull_transaction("_Test")
+
+        self.assertEqual(result["status"], "success")
+        self.assertIn("Accept", result["message"])
+
     def test_processing_of_only_one_succes_callback_payload(self):
         mpesa_account = frappe.db.get_value(
             "Payment Gateway Account",

--- a/frappe_mpsa_payments/hooks.py
+++ b/frappe_mpsa_payments/hooks.py
@@ -171,7 +171,10 @@ scheduler_events = {
         "*/15 * * * *": [
             "frappe_mpsa_payments.services.b2c_scheduler_service.update_b2c_disbursement_statuses"
         ]
-    }
+    },
+    "daily": [
+        "frappe_mpsa_payments.services.pull_transaction_scheduler_service.run_daily_pull_transactions"
+    ],
 }
 
 # Testing

--- a/frappe_mpsa_payments/hooks.py
+++ b/frappe_mpsa_payments/hooks.py
@@ -172,8 +172,8 @@ scheduler_events = {
             "frappe_mpsa_payments.services.b2c_scheduler_service.update_b2c_disbursement_statuses"
         ]
     },
-    "daily": [
-        "frappe_mpsa_payments.services.pull_transaction_scheduler_service.run_daily_pull_transactions"
+    "hourly": [
+        "frappe_mpsa_payments.services.b2c_pull_transaction_scheduler_service.run_hourly_pull_transactions"
     ],
 }
 

--- a/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
+++ b/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
@@ -24,5 +24,5 @@ def run_hourly_pull_transactions():
         except Exception:
             frappe.log_error(
                 frappe.get_traceback(),
-                f"[Daily Pull Transaction Error] {row.name}",
+                f"[Hourly Pull Transaction Error] {row.name}",
             )

--- a/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
+++ b/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
@@ -7,7 +7,7 @@ from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import pull_transa
 def run_hourly_pull_transactions():
     settings_list = frappe.get_all(
         "Mpesa Settings",
-        filters={"enable_daily_pull_transactions": 1},
+        filters={"enable_hourly_pull_transactions": 1},
         fields=["name"],
     )
     end_date = now_datetime()

--- a/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
+++ b/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
@@ -4,14 +4,14 @@ from frappe.utils import add_to_date, now_datetime
 from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import pull_transactions
 
 
-def run_daily_pull_transactions():
+def run_hourly_pull_transactions():
     settings_list = frappe.get_all(
         "Mpesa Settings",
         filters={"enable_daily_pull_transactions": 1},
         fields=["name"],
     )
     end_date = now_datetime()
-    start_date = add_to_date(end_date, hours=-24)
+    start_date = add_to_date(end_date, hours=-2)
 
     for row in settings_list:
         try:

--- a/frappe_mpsa_payments/services/pull_transaction_scheduler_service.py
+++ b/frappe_mpsa_payments/services/pull_transaction_scheduler_service.py
@@ -5,24 +5,24 @@ from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import pull_transa
 
 
 def run_daily_pull_transactions():
-	settings_list = frappe.get_all(
-		"Mpesa Settings",
-		filters={"enable_daily_pull_transactions": 1},
-		fields=["name"],
-	)
-	end_date = now_datetime()
-	start_date = add_to_date(end_date, hours=-24)
+    settings_list = frappe.get_all(
+        "Mpesa Settings",
+        filters={"enable_daily_pull_transactions": 1},
+        fields=["name"],
+    )
+    end_date = now_datetime()
+    start_date = add_to_date(end_date, hours=-24)
 
-	for row in settings_list:
-		try:
-			pull_transactions(
-				mpesa_settings=row.name,
-				start_date=start_date.strftime("%Y-%m-%d %H:%M:%S"),
-				end_date=end_date.strftime("%Y-%m-%d %H:%M:%S"),
-				offset=0,
-			)
-		except Exception:
-			frappe.log_error(
-				frappe.get_traceback(),
-				f"[Daily Pull Transaction Error] {row.name}",
-			)
+    for row in settings_list:
+        try:
+            pull_transactions(
+                mpesa_settings=row.name,
+                start_date=start_date.strftime("%Y-%m-%d %H:%M:%S"),
+                end_date=end_date.strftime("%Y-%m-%d %H:%M:%S"),
+                offset=0,
+            )
+        except Exception:
+            frappe.log_error(
+                frappe.get_traceback(),
+                f"[Daily Pull Transaction Error] {row.name}",
+            )

--- a/frappe_mpsa_payments/services/pull_transaction_scheduler_service.py
+++ b/frappe_mpsa_payments/services/pull_transaction_scheduler_service.py
@@ -1,0 +1,28 @@
+import frappe
+from frappe.utils import add_to_date, now_datetime
+
+from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import pull_transactions
+
+
+def run_daily_pull_transactions():
+	settings_list = frappe.get_all(
+		"Mpesa Settings",
+		filters={"enable_daily_pull_transactions": 1},
+		fields=["name"],
+	)
+	end_date = now_datetime()
+	start_date = add_to_date(end_date, hours=-24)
+
+	for row in settings_list:
+		try:
+			pull_transactions(
+				mpesa_settings=row.name,
+				start_date=start_date.strftime("%Y-%m-%d %H:%M:%S"),
+				end_date=end_date.strftime("%Y-%m-%d %H:%M:%S"),
+				offset=0,
+			)
+		except Exception:
+			frappe.log_error(
+				frappe.get_traceback(),
+				f"[Daily Pull Transaction Error] {row.name}",
+			)

--- a/frappe_mpsa_payments/utils/doctype_names.py
+++ b/frappe_mpsa_payments/utils/doctype_names.py
@@ -3,6 +3,7 @@ from typing import Final
 PUBLIC_CERTIFICATES_DOCTYPE: Final[str] = "Mpesa Public Key Certificate"
 MPESA_SETTINGS_DOCTYPE: Final[str] = "Mpesa Settings"
 MPESA_EXPRESS_REQUEST_DOCTYPE: Final[str] = "Mpesa Express Request"
+MPESA_C2B_PAYMENT_REGISTER_DOCTYPE: Final[str] = "Mpesa C2B Payment Register"
 ACCESS_TOKENS_DOCTYPE: Final[str] = ""
 B2C_REQUEST_DOCTYPE: Final[str] = "B2C Disbursement Request"
 


### PR DESCRIPTION
FEAT: Pull Transactions API added
- with hourly scheduler (which pulls last 2 hours), with deduplication.
- all settings within mpesa-settings singleton
- nominated number must be in 254 format. Nominated number displays from the admin login for Mpesa Portal, under Organization > Details.
- Register URL button & manual Pull Transaction button enabled with maximum 48 hour window.
- Consolidated Error Log entry for the missed transactions (for reporting purposes)

FIX:
- transaction status result loop
- sandbox datetime format