### PR TITLE
fix: show when pull transactions actually fail, add bulk actions

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -24,9 +24,13 @@ from ...utils.utils import (
     update_mpesa_request_status,
 )
 from .mpesa_response_handler import (
+    BULK_PULL_FLAG,
+    BULK_PULL_RESULTS_FLAG,
     balance_query_on_success,
+    publish_pull_result,
     pull_transaction_on_error,
     pull_transaction_on_success,
+    record_pull_outcome,
     stk_push_on_success,
     transaction_status_on_success,
 )
@@ -1025,6 +1029,25 @@ def verify_transaction(**kwargs) -> None:
     )
 
 
+def build_pull_payload(
+    mpesa_settings: str, start_date: str, end_date: str, offset: int = 0
+) -> dict:
+    def _fmt(dt_str: str) -> str:
+        return datetime.datetime.strptime(dt_str.strip(), "%Y-%m-%d %H:%M:%S").strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
+    settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, mpesa_settings)
+    shortcode = settings.till_number if settings.sandbox else settings.business_shortcode
+
+    return {
+        "ShortCode": shortcode,
+        "StartDate": _fmt(start_date),
+        "EndDate": _fmt(end_date),
+        "OffSetValue": str(int(offset)),
+    }
+
+
 @frappe.whitelist()
 def pull_transactions(
     mpesa_settings: str,
@@ -1032,21 +1055,8 @@ def pull_transactions(
     end_date: str,
     offset: int = 0,
 ) -> dict:
-    def _fmt(dt_str: str) -> str:
-        return datetime.datetime.strptime(dt_str.strip(), "%Y-%m-%d %H:%M:%S").strftime(
-            "%Y-%m-%d %H:%M:%S"
-        )
-
     try:
-        settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, mpesa_settings)
-        shortcode = settings.till_number if settings.sandbox else settings.business_shortcode
-
-        payload = {
-            "ShortCode": shortcode,
-            "StartDate": _fmt(start_date),
-            "EndDate": _fmt(end_date),
-            "OffSetValue": str(int(offset)),
-        }
+        payload = build_pull_payload(mpesa_settings, start_date, end_date, offset)
 
     except Exception:
         frappe.log_error(frappe.get_traceback(), "Mpesa Pull Transaction Error")
@@ -1070,34 +1080,280 @@ def pull_transactions(
     }
 
 
-def execute_pull_transactions(mpesa_settings: str, payload: dict) -> None:
-    """Call Safaricom's pull transactions endpoint and process the results.
+# Connect timeouts to api.safaricom.co.ke are routine when the hourly job fans
+# out one request per Mpesa Settings doc. Retry rather than lose the window.
+PULL_MAX_ATTEMPTS = 3
+PULL_RETRY_BACKOFF_SECONDS = 2
 
-    Runs in the background (enqueued by `pull_transactions`) since the
-    Safaricom call plus C2B record creation/reconciliation can take a while
-    and shouldn't hold up the whitelisted request/response cycle.
+# Safety stop for the pagination walk, in case TotalPages is missing or wrong.
+PULL_MAX_PAGES = 50
+
+
+def execute_pull_transactions(mpesa_settings: str, payload: dict) -> None:
+    """Pull every page Safaricom has for the window, not just the first one.
+
+    Safaricom paginates: a 48h window on a busy shortcode came back as
+    TotalRecords 318 across TotalPages 4. We used to send OffSetValue once and
+    import whatever single page came back, silently dropping the rest unless
+    someone manually re-ran with offset 1, 2, 3. Now we walk the pages.
+
+    Runs in the background (enqueued by `pull_transactions`). Connection-level
+    failures are retried per page: the hourly job fans out one request per
+    Mpesa Settings doc against a single Safaricom host, so transient connect
+    timeouts are expected and shouldn't be treated as a lost pull.
     """
+    # A multi-page pull would otherwise fire one alert per page. Collect them
+    # and report once, unless a bulk run is already collecting.
+    outer_bulk = bool(frappe.flags.get(BULK_PULL_FLAG))
+    if not outer_bulk:
+        frappe.flags[BULK_PULL_FLAG] = True
+        frappe.flags[BULK_PULL_RESULTS_FLAG] = []
+
+    results = frappe.flags.get(BULK_PULL_RESULTS_FLAG)
+    first_result = len(results or [])
+
+    page = frappe.utils.cint(payload.get("OffSetValue") or 0)
+    last_error = None
+
     try:
-        process_request(
-            endpoint="/pulltransactions/v1/query",
-            settings_name=mpesa_settings,
-            method="POST",
-            payload=payload,
-            success_callback=pull_transaction_on_success,
-            error_callback=pull_transaction_on_error,
-            request_description="Mpesa Pull Transaction",
-            doctype=MPESA_SETTINGS_DOCTYPE,
-            document_name=mpesa_settings,
+        while page < PULL_MAX_PAGES:
+            payload["OffSetValue"] = str(page)
+            data = _pull_one_page(mpesa_settings, payload)
+
+            if isinstance(data, Exception):
+                last_error = data
+                break
+            if data is None:
+                break
+
+            total_pages = frappe.utils.cint(data.get("TotalPages") or 0)
+            page += 1
+            if page >= total_pages:
+                break
+    finally:
+        if not outer_bulk:
+            frappe.flags[BULK_PULL_FLAG] = False
+
+    if last_error is None:
+        if not outer_bulk:
+            _publish_pull_summary(mpesa_settings, (results or [])[first_result:])
+        return
+
+    _handle_pull_failure(mpesa_settings, last_error)
+
+
+def _pull_one_page(mpesa_settings: str, payload: dict):
+    """One page, with retries. Returns the response, None, or the exception."""
+    for attempt in range(PULL_MAX_ATTEMPTS):
+        try:
+            return process_request(
+                endpoint="/pulltransactions/v1/query",
+                settings_name=mpesa_settings,
+                method="POST",
+                payload=payload,
+                success_callback=pull_transaction_on_success,
+                error_callback=pull_transaction_on_error,
+                request_description="Mpesa Pull Transaction",
+                doctype=MPESA_SETTINGS_DOCTYPE,
+                document_name=mpesa_settings,
+            )
+        except (
+            requests.exceptions.ConnectTimeout,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ReadTimeout,
+        ) as e:
+            if attempt < PULL_MAX_ATTEMPTS - 1:
+                time.sleep(PULL_RETRY_BACKOFF_SECONDS * (2**attempt))
+                continue
+            return e
+        except Exception as e:
+            # Not a network blip - don't burn retries on a real bug.
+            return e
+
+    return None
+
+
+def _publish_pull_summary(mpesa_settings: str, page_results: list) -> None:
+    """One alert for the whole pull, however many pages it took."""
+    if not page_results:
+        return
+
+    if len(page_results) == 1:
+        publish_pull_result(page_results[0])
+        return
+
+    created = sum(r.get("created") or 0 for r in page_results)
+    skipped = sum(r.get("skipped") or 0 for r in page_results)
+    failed = sum(r.get("failed") or 0 for r in page_results)
+
+    publish_pull_result(
+        {
+            "status": "success" if created or skipped else "warning",
+            "title": "Pull Transaction Complete",
+            "message": (
+                f"{mpesa_settings}: {created} record(s) imported, {skipped} skipped, "
+                f"{failed} failed across {len(page_results)} page(s)."
+            ),
+            "count": created,
+            "settings": mpesa_settings,
+            "created": created,
+            "skipped": skipped,
+            "failed": failed,
+        }
+    )
+
+
+def _handle_pull_failure(mpesa_settings: str, error) -> None:
+    is_network = isinstance(
+        error,
+        (
+            requests.exceptions.ConnectTimeout,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ReadTimeout,
+        ),
+    )
+
+    if is_network:
+        frappe.log_error(
+            f"Gave up after {PULL_MAX_ATTEMPTS} attempts: {error}",
+            f"Mpesa Pull Transaction Error [{mpesa_settings}]",
         )
-    except Exception:
-        frappe.log_error(frappe.get_traceback(), "Mpesa Pull Transaction Error")
-        frappe.publish_realtime(
-            event="mpesa_pull_transaction_complete",
-            message={
-                "status": "error",
-                "title": "Pull Transaction Failed",
-                "message": "Failed to pull transactions. Check Error Logs.",
-                "count": 0,
-            },
-            user=frappe.session.user,
-        )
+        detail = f"connection failed after {PULL_MAX_ATTEMPTS} attempts"
+    else:
+        frappe.log_error(str(error), f"Mpesa Pull Transaction Error [{mpesa_settings}]")
+        detail = "Check Error Logs"
+
+    record_pull_outcome(mpesa_settings, status="Error", message=str(error or detail))
+
+    publish_pull_result(
+        {
+            "status": "error",
+            "title": "Pull Transaction Failed",
+            "message": f"{mpesa_settings}: Failed to pull transactions - {detail}.",
+            "count": 0,
+            "settings": mpesa_settings,
+        }
+    )
+
+
+@frappe.whitelist()
+def bulk_pull_transactions(
+    settings_names: str | list | None = None,
+    start_date: str = "",
+    end_date: str = "",
+    offset: int = 0,
+) -> dict:
+    """Queue one pull covering many shortcodes, reporting a single summary."""
+    frappe.only_for(["System Manager", "Administrator"])
+
+    if isinstance(settings_names, str):
+        settings_names = frappe.parse_json(settings_names)
+
+    if not settings_names:
+        settings_names = [
+            row.name
+            for row in frappe.get_all(
+                MPESA_SETTINGS_DOCTYPE,
+                filters={"enable_hourly_pull_transactions": 1},
+                fields=["name"],
+            )
+        ]
+
+    if not settings_names:
+        return {"status": "error", "message": _("No Mpesa Settings selected.")}
+
+    if not start_date or not end_date:
+        return {"status": "error", "message": _("Start and end date are required.")}
+
+    frappe.enqueue(
+        "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api"
+        ".execute_bulk_pull_transactions",
+        queue="long",
+        timeout=3600,
+        settings_names=settings_names,
+        start_date=start_date,
+        end_date=end_date,
+        offset=offset,
+    )
+
+    return {
+        "status": "success",
+        "message": _("Pull queued for {0} shortcode(s). One summary will follow.").format(
+            len(settings_names)
+        ),
+        "count": len(settings_names),
+    }
+
+
+def execute_bulk_pull_transactions(
+    settings_names: list, start_date: str, end_date: str, offset: int = 0
+) -> None:
+    """Pull each shortcode in turn, collecting results into one summary.
+
+    Runs the pulls inline rather than enqueuing one job each, so the per-pull
+    toasts can be suppressed via BULK_PULL_FLAG and replaced by a single message.
+    """
+    frappe.flags[BULK_PULL_FLAG] = True
+    frappe.flags[BULK_PULL_RESULTS_FLAG] = []
+
+    skipped_settings = []
+
+    try:
+        for name in settings_names:
+            try:
+                payload = build_pull_payload(name, start_date, end_date, offset)
+            except Exception as e:
+                skipped_settings.append(f"{name}: {e}")
+                continue
+
+            try:
+                execute_pull_transactions(mpesa_settings=name, payload=payload)
+            except Exception:
+                frappe.log_error(
+                    frappe.get_traceback(),
+                    f"Mpesa Bulk Pull Error [{name}]",
+                )
+            frappe.db.commit()
+
+        results = frappe.flags.get(BULK_PULL_RESULTS_FLAG) or []
+    finally:
+        frappe.flags[BULK_PULL_FLAG] = False
+
+    imported = sum(r.get("created") or 0 for r in results)
+    no_data = [r for r in results if r.get("response_code") == "1001"]
+    errored = [r for r in results if r.get("status") == "error"]
+
+    summary_lines = [
+        f"Window: {start_date} -> {end_date}",
+        f"Shortcodes attempted: {len(settings_names)}",
+        f"Records imported: {imported}",
+        f"Returned no data (1001): {len(no_data)}",
+        f"Errored: {len(errored)}",
+        "",
+        "No data: " + ", ".join(str(r.get("settings")) for r in no_data),
+        "",
+        "Errors:",
+    ]
+    summary_lines += [f"  {r.get('message')}" for r in errored]
+    if skipped_settings:
+        summary_lines += ["", "Skipped (bad config):"] + [
+            f"  {s}" for s in skipped_settings
+        ]
+
+    frappe.log_error(
+        title="Mpesa Bulk Pull Transactions Complete",
+        message="\n".join(summary_lines),
+    )
+
+    frappe.publish_realtime(
+        event="mpesa_bulk_pull_complete",
+        message={
+            "status": "success" if not errored else "warning",
+            "title": "Bulk Pull Complete",
+            "message": (
+                f"{imported} record(s) imported across {len(settings_names)} shortcode(s). "
+                f"{len(no_data)} returned no data, {len(errored)} errored."
+            ),
+        },
+        user=frappe.session.user,
+    )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -105,6 +105,80 @@ def stk_push_on_success(
         raise
 
 
+PULL_SUCCESS_CODE = "1000"
+
+# Safaricom returns this with HTTP 200 both when a window genuinely has no
+# transactions and when the shortcode is not provisioned for Pull at all
+# (the "or Organization Name not available" half of the message). Treating it
+# as a plain success is what let ~4,600 failed pulls report "0 imported".
+PULL_NO_RECORDS_CODE = "1001"
+
+PULL_NO_RECORDS_HINT = (
+    "Safaricom returns 1001 both for an empty window and for a shortcode that is "
+    "not provisioned for Pull. If this repeats for a shortcode that is known to be "
+    "receiving payments, the registration or Organization Name is likely missing "
+    "on Safaricom's side."
+)
+
+
+BULK_PULL_FLAG = "mpesa_bulk_pull"
+BULK_PULL_RESULTS_FLAG = "mpesa_bulk_pull_results"
+
+
+def publish_pull_result(message: dict) -> None:
+    """Emit one toast per pull - unless a bulk run is collecting them.
+
+    A bulk pull over 69 shortcodes would otherwise fire 69 separate popups. The
+    bulk worker sets the flag, runs everything in its own job, and publishes a
+    single summary at the end.
+    """
+    if frappe.flags.get(BULK_PULL_FLAG):
+        results = frappe.flags.get(BULK_PULL_RESULTS_FLAG)
+        if results is None:
+            results = []
+            frappe.flags[BULK_PULL_RESULTS_FLAG] = results
+        results.append(message)
+        return
+
+    frappe.publish_realtime(
+        event="mpesa_pull_transaction_complete",
+        message=message,
+        user=frappe.session.user,
+    )
+
+
+def record_pull_outcome(
+    settings_name: str,
+    status: str,
+    response_code: str = "",
+    message: str = "",
+) -> None:
+    """Persist the last pull outcome on Mpesa Settings.
+
+    Without this, a shortcode that never returns data is indistinguishable from
+    one that simply had a quiet hour. Written with db_set on a fresh doc load so
+    it survives regardless of what the caller does with its own copy.
+    """
+    try:
+        frappe.db.set_value(
+            MPESA_SETTINGS_DOCTYPE,
+            settings_name,
+            {
+                "last_pull_status": status,
+                "last_pull_response_code": response_code or "",
+                "last_pull_message": (message or "")[:500],
+                "last_pull_on": now_datetime(),
+            },
+            update_modified=False,
+        )
+    except Exception:
+        # Never let bookkeeping break the pull itself.
+        frappe.log_error(
+            frappe.get_traceback(),
+            f"Mpesa Pull Transaction: could not record outcome for {settings_name}",
+        )
+
+
 def _flatten_pull_transactions(raw) -> list:
     if isinstance(raw, dict):
         return [raw]
@@ -122,6 +196,54 @@ def _flatten_pull_transactions(raw) -> list:
 def pull_transaction_on_success(response: dict, document_name: str, **kwargs) -> None:
     settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, kwargs.get("settings_name", document_name))
     shortcode = settings.till_number if settings.sandbox else settings.business_shortcode
+
+    # This callback runs on any HTTP 2xx, but Safaricom signals application-level
+    # failure in the body while still returning 200. Anything other than 1000 means
+    # no data was returned and must not be reported as a successful import.
+    response_code = str(response.get("ResponseCode") or "")
+    if response_code and response_code != PULL_SUCCESS_CODE:
+        response_message = str(
+            response.get("ResponseMessage") or response.get("errorMessage") or ""
+        )
+        is_no_records = response_code == PULL_NO_RECORDS_CODE
+
+        log_message = [
+            f"Settings: {settings.name}",
+            f"ShortCode: {shortcode!r}",
+            f"ResponseCode: {response_code}",
+            f"ResponseMessage: {response_message}",
+            f"Window: {kwargs.get('payload', {})}",
+        ]
+        if is_no_records:
+            log_message.append("")
+            log_message.append(PULL_NO_RECORDS_HINT)
+
+        frappe.log_error(
+            title=f"Mpesa Pull Transaction: {response_code} from Safaricom",
+            message="\n".join(log_message),
+        )
+
+        record_pull_outcome(
+            settings.name,
+            status="No Data" if is_no_records else "Error",
+            response_code=response_code,
+            message=response_message,
+        )
+
+        publish_pull_result(
+            {
+                "status": "warning" if is_no_records else "error",
+                "title": "Pull Transaction Returned No Data",
+                "message": (
+                    f"{settings.name}: Safaricom returned {response_code} - "
+                    f"{response_message or 'no message'}. Nothing imported."
+                ),
+                "count": 0,
+                "response_code": response_code,
+                "settings": settings.name,
+            }
+        )
+        return
 
     # Safaricom's actual response nests one list of transaction dicts inside
     # "Response" (confirmed via live sandbox test) - not the "Transactions.Transaction"
@@ -184,31 +306,50 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
             message=frappe.as_json(created_records),
         )
 
-    owner = frappe.session.user
-    frappe.publish_realtime(
-        event="mpesa_pull_transaction_complete",
-        message={
+    record_pull_outcome(
+        settings.name,
+        status="Success",
+        response_code=response_code or PULL_SUCCESS_CODE,
+        message=f"{created} imported, {skipped} skipped, {failed} failed "
+        f"from {len(transactions)} returned",
+    )
+
+    publish_pull_result(
+        {
             "status": "success" if created > 0 or skipped == len(transactions) else "warning",
             "title": "Pull Transaction Complete",
-            "message": f"{created} record(s) imported, {skipped} skipped, {failed} failed.",
+            "message": f"{settings.name}: {created} record(s) imported, {skipped} skipped, {failed} failed.",
             "count": created,
-        },
-        user=owner,
+            "response_code": response_code or PULL_SUCCESS_CODE,
+            "settings": settings.name,
+            "created": created,
+            "skipped": skipped,
+            "failed": failed,
+        }
     )
 
 
 def pull_transaction_on_error(response: dict, document_name: str, **kwargs) -> None:
+    settings_name = kwargs.get("settings_name") or document_name
     frappe.log_error(
         title="Mpesa Pull Transaction: Safaricom Error",
         message=frappe.as_json(response),
     )
-    frappe.publish_realtime(
-        event="mpesa_pull_transaction_complete",
-        message={
+    error_message = response.get(
+        "errorMessage", "Safaricom rejected the pull request. Check Error Logs."
+    )
+    record_pull_outcome(
+        settings_name,
+        status="Error",
+        response_code=str(response.get("errorCode") or response.get("ResponseCode") or ""),
+        message=str(error_message),
+    )
+    publish_pull_result(
+        {
             "status": "error",
             "title": "Pull Transaction Failed",
-            "message": response.get("errorMessage", "Safaricom rejected the pull request. Check Error Logs."),
+            "message": f"{settings_name}: {error_message}",
             "count": 0,
-        },
-        user=frappe.session.user,
+            "settings": settings_name,
+        }
     )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.js
@@ -258,13 +258,6 @@ frappe.ui.form.on("Mpesa Settings", {
 					fieldname: "date_range_display",
 					fieldtype: "HTML",
 				},
-				{
-					label: __("Offset"),
-					fieldname: "offset",
-					fieldtype: "Int",
-					default: 0,
-					description: __("Page offset for pagination (0 = first page)"),
-				},
 			],
 			primary_action_label: __("Pull"),
 			primary_action: (values) => {
@@ -280,7 +273,6 @@ frappe.ui.form.on("Mpesa Settings", {
 						mpesa_settings: frm.doc.name,
 						start_date: start_date,
 						end_date: values.end_date,
-						offset: values.offset || 0,
 					},
 					freeze: true,
 					freeze_message: __("Pulling transactions from M-Pesa..."),

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -33,6 +33,14 @@
   "initiator_password",
   "pull_transaction_nominated_number",
   "enable_hourly_pull_transactions",
+  "pull_registration_status",
+  "pull_registered_on",
+  "pull_registration_message",
+  "pull_status_section",
+  "last_pull_status",
+  "last_pull_response_code",
+  "last_pull_on",
+  "last_pull_message",
   "balance_details_section",
   "utility_account",
   "working_account",
@@ -307,6 +315,59 @@
    "fieldtype": "Check",
    "label": "Enable Hourly Pull Transactions",
    "description": "If checked, automatically pulls transactions for the last 2 hours once every hour."
+  },
+  {
+   "description": "Set by Register Pull Transaction. 'Already Registered' means Safaricom already has this shortcode enrolled.",
+   "fieldname": "pull_registration_status",
+   "fieldtype": "Select",
+   "label": "Pull Registration Status",
+   "options": "\nRegistered\nAlready Registered\nFailed",
+   "read_only": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "pull_registered_on",
+   "fieldtype": "Datetime",
+   "label": "Pull Registered On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "pull_registration_message",
+   "fieldtype": "Small Text",
+   "label": "Pull Registration Message",
+   "read_only": 1
+  },
+  {
+   "fieldname": "pull_status_section",
+   "fieldtype": "Section Break",
+   "label": "Last Pull Result"
+  },
+  {
+   "description": "Success = Safaricom returned data. No Data = code 1001, which also means the shortcode may not be provisioned for Pull. Error = the request failed.",
+   "fieldname": "last_pull_status",
+   "fieldtype": "Select",
+   "label": "Last Pull Status",
+   "options": "\nSuccess\nNo Data\nError",
+   "read_only": 1,
+   "in_list_view": 1
+  },
+  {
+   "fieldname": "last_pull_response_code",
+   "fieldtype": "Data",
+   "label": "Last Pull Response Code",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_pull_on",
+   "fieldtype": "Datetime",
+   "label": "Last Pull On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_pull_message",
+   "fieldtype": "Small Text",
+   "label": "Last Pull Message",
+   "read_only": 1
   }
  ],
  "links": [],

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -4,6 +4,7 @@
 
 import base64
 import re
+import time
 from json import dumps, loads
 from typing import Any
 from urllib.parse import urlparse
@@ -19,6 +20,7 @@ from frappe.model.document import Document
 from frappe.utils import (
     fmt_money,
     get_request_site_address,
+    now_datetime,
 )
 from frappe.utils.file_manager import get_file_path
 
@@ -537,8 +539,46 @@ def trigger_transaction_status(mpesa_settings, transaction_id, remarks="OK"):
         return {"status": "error", "message": str(e)}
 
 
+# Safaricom throttles bursts; pace the batch rather than fire 69 requests flat out.
+BULK_REGISTRATION_DELAY_SECONDS = 1
+
+PULL_REGISTRATION_CALLBACK = (
+    "frappe_mpsa_payments.frappe_mpsa_payments.doctype"
+    ".mpesa_settings.mpesa_settings.pull_transaction_callback"
+)
+
+
+def _record_registration_outcome(settings_name: str, status: str, message: str) -> None:
+    """Persist pull registration state so enrollment is visible in the list view."""
+    try:
+        frappe.db.set_value(
+            "Mpesa Settings",
+            settings_name,
+            {
+                "pull_registration_status": status,
+                "pull_registration_message": (message or "")[:500],
+                "pull_registered_on": now_datetime(),
+            },
+            update_modified=False,
+        )
+    except Exception:
+        frappe.log_error(
+            frappe.get_traceback(),
+            f"Mpesa Pull Registration: could not record outcome for {settings_name}",
+        )
+
+
 @frappe.whitelist()
-def register_pull_transaction(mpesa_settings: str) -> dict:
+def register_pull_transaction(mpesa_settings: str, callback_url: str | None = None) -> dict:
+    """Register a shortcode with Safaricom for Pull Transactions.
+
+    `callback_url` exists so bulk registration can capture the URL in the web
+    request context and pass it down. Built from the request Host header,
+    `build_callback_url` silently falls back to conf.host_name (or
+    http://<site>) when there is no request - and since Safaricom rejects
+    re-registration with "Shortcode already Registered!", a wrong URL baked in
+    from a background job cannot be corrected afterwards.
+    """
     import requests as _requests
 
     from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import get_token
@@ -571,9 +611,7 @@ def register_pull_transaction(mpesa_settings: str) -> dict:
         shortcode = (
             settings.till_number if settings.sandbox else settings.business_shortcode
         )
-        callback_url = build_callback_url(
-            "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.pull_transaction_callback"
-        )
+        callback_url = callback_url or build_callback_url(PULL_REGISTRATION_CALLBACK)
 
         payload = {
             "ShortCode": shortcode,
@@ -596,21 +634,147 @@ def register_pull_transaction(mpesa_settings: str) -> dict:
         data = resp.json()
     except Exception as e:
         frappe.log_error(title="Mpesa Pull Transaction Registration Error", message=str(e))
+        _record_registration_outcome(mpesa_settings, "Failed", str(e))
         return {"status": "error", "message": str(e)}
 
     if data.get("Response Status") == "1000":
-        return {
-            "status": "success",
-            "message": data.get("Response Description", "Registered successfully"),
-        }
+        description = data.get("Response Description", "Registered successfully")
+        _record_registration_outcome(mpesa_settings, "Registered", description)
+        return {"status": "success", "message": description}
+
+    description = data.get("Response Description", "Registration failed")
+
+    # Safaricom rejects a second registration for a shortcode already enrolled.
+    # That is not a failure to act on - it means the shortcode is already set up.
+    if "already registered" in str(description).lower():
+        _record_registration_outcome(mpesa_settings, "Already Registered", description)
+        return {"status": "already_registered", "message": description}
 
     frappe.log_error(
         title="Mpesa Pull Transaction Registration Error", message=str(data)
     )
+    _record_registration_outcome(mpesa_settings, "Failed", description)
+    return {"status": "error", "message": description}
+
+
+@frappe.whitelist()
+def bulk_register_pull_transactions(
+    settings_names: str | list | None = None, dry_run: int | bool = 0
+) -> dict:
+    """Queue pull registration for many shortcodes at once.
+
+    Registration is effectively one-way (Safaricom rejects re-registration), so
+    the CallBackURL is resolved here, inside the web request, and passed to the
+    worker rather than rebuilt there from an unreliable fallback.
+    """
+    from frappe_mpsa_payments.utils.utils import build_callback_url
+
+    frappe.only_for(["System Manager", "Administrator"])
+
+    if isinstance(settings_names, str):
+        settings_names = frappe.parse_json(settings_names)
+
+    if not settings_names:
+        settings_names = [
+            row.name
+            for row in frappe.get_all(
+                "Mpesa Settings",
+                filters={"pull_transaction_nominated_number": ["!=", ""]},
+                fields=["name"],
+            )
+        ]
+
+    if not settings_names:
+        return {"status": "error", "message": _("No Mpesa Settings to register.")}
+
+    try:
+        callback_url = build_callback_url(PULL_REGISTRATION_CALLBACK)
+    except RuntimeError:
+        # build_callback_url reads the request Host header and raises
+        # "object is not bound" with no request. Better to stop here than to
+        # register 60+ shortcodes against a guessed hostname we cannot correct.
+        frappe.throw(
+            _(
+                "Bulk pull registration must be run from the web interface so the "
+                "callback URL can be read from the request. Registration cannot be "
+                "undone, so it will not run with a guessed hostname."
+            )
+        )
+
+    if frappe.utils.cint(dry_run):
+        return {
+            "status": "dry_run",
+            "message": _("Would register {0} shortcode(s) with callback {1}").format(
+                len(settings_names), callback_url
+            ),
+            "count": len(settings_names),
+            "callback_url": callback_url,
+            "settings": settings_names,
+        }
+
+    frappe.enqueue(
+        "frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings"
+        ".mpesa_settings.execute_bulk_pull_registration",
+        queue="long",
+        timeout=3600,
+        settings_names=settings_names,
+        callback_url=callback_url,
+    )
+
     return {
-        "status": "error",
-        "message": data.get("Response Description", "Registration failed"),
+        "status": "success",
+        "message": _("Queued registration for {0} shortcode(s).").format(
+            len(settings_names)
+        ),
+        "count": len(settings_names),
+        "callback_url": callback_url,
     }
+
+
+def execute_bulk_pull_registration(settings_names: list, callback_url: str) -> None:
+    """Register each shortcode in turn, isolating failures so one cannot abort the batch."""
+    registered, already, failed = [], [], []
+
+    for name in settings_names:
+        try:
+            result = register_pull_transaction(name, callback_url=callback_url)
+            status = result.get("status")
+            if status == "success":
+                registered.append(name)
+            elif status == "already_registered":
+                already.append(name)
+            else:
+                failed.append(f"{name}: {result.get('message')}")
+        except Exception as e:
+            # Includes the frappe.throw for a missing nominated number.
+            failed.append(f"{name}: {e}")
+            _record_registration_outcome(name, "Failed", str(e))
+
+        frappe.db.commit()
+        time.sleep(BULK_REGISTRATION_DELAY_SECONDS)
+
+    summary = (
+        f"Registered: {len(registered)}\n"
+        f"Already registered: {len(already)}\n"
+        f"Failed: {len(failed)}\n\n"
+        f"Callback URL used: {callback_url}\n\n"
+        f"Newly registered: {registered}\n\n"
+        f"Failures:\n" + "\n".join(failed)
+    )
+    frappe.log_error(title="Mpesa Bulk Pull Registration Complete", message=summary)
+
+    frappe.publish_realtime(
+        event="mpesa_bulk_pull_registration_complete",
+        message={
+            "status": "success" if not failed else "warning",
+            "title": "Bulk Pull Registration Complete",
+            "message": (
+                f"{len(registered)} registered, {len(already)} already registered, "
+                f"{len(failed)} failed."
+            ),
+        },
+        user=frappe.session.user,
+    )
 
 
 @frappe.whitelist(allow_guest=True)

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings_list.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings_list.js
@@ -1,0 +1,171 @@
+frappe.listview_settings["Mpesa Settings"] = {
+	add_fields: ["pull_registration_status", "last_pull_status"],
+
+	get_indicator: function (doc) {
+		if (doc.last_pull_status === "Success") {
+			return [__("Pull OK"), "green", "last_pull_status,=,Success"];
+		}
+		if (doc.last_pull_status === "No Data") {
+			return [__("Pull: No Data"), "orange", "last_pull_status,=,No Data"];
+		}
+		if (doc.last_pull_status === "Error") {
+			return [__("Pull Error"), "red", "last_pull_status,=,Error"];
+		}
+		return [__("Not Pulled"), "gray", "last_pull_status,=,"];
+	},
+
+	onload: function (listview) {
+		listview.page.add_action_item(__("Register Pull Transactions"), () => {
+			bulk_register(listview.get_checked_items(true) || []);
+		});
+
+		listview.page.add_action_item(__("Pull Transactions"), () => {
+			bulk_pull(listview.get_checked_items(true) || []);
+		});
+
+		listview.page.add_menu_item(__("Register Pull Transactions (All)"), () => {
+			bulk_register([]);
+		});
+
+		listview.page.add_menu_item(__("Pull Transactions (All Enabled)"), () => {
+			bulk_pull([]);
+		});
+	},
+};
+
+function bulk_pull(selected) {
+	// Matches the single-doc dialog: Safaricom's window is 48h, so only the
+	// end is worth asking for. All pages within it are fetched automatically.
+	const DATE_FORMAT = "YYYY-MM-DD HH:mm:ss";
+	const PULL_WINDOW_HOURS = 48;
+
+	const render_range = () => {
+		const end_value = dialog.get_value("end_date") || frappe.datetime.now_datetime();
+		const end_moment = moment(end_value, DATE_FORMAT);
+		const start_moment = end_moment.clone().subtract(PULL_WINDOW_HOURS, "hours");
+		dialog.fields_dict.date_range_display.$wrapper.html(
+			`<p>${__("Pulling transactions from {0} to {1}", [
+				`<b>${start_moment.format(DATE_FORMAT)}</b>`,
+				`<b>${end_moment.format(DATE_FORMAT)}</b>`,
+			])}</p>`
+		);
+	};
+
+	const dialog = new frappe.ui.Dialog({
+		title: selected.length
+			? __("Pull Transactions for {0} shortcode(s)", [selected.length])
+			: __("Pull Transactions for all hourly-enabled shortcodes"),
+		fields: [
+			{
+				fieldname: "end_date",
+				fieldtype: "Datetime",
+				label: __("End Date"),
+				reqd: 1,
+				default: frappe.datetime.now_datetime(),
+				onchange: () => render_range(),
+			},
+			{
+				fieldname: "date_range_display",
+				fieldtype: "HTML",
+			},
+			{
+				fieldtype: "HTML",
+				options: `<p class="text-muted small">${__(
+					"Runs in background. Check error log for combined result. Existing transactions get skipped automatically."
+				)}</p>`,
+			},
+		],
+		primary_action_label: __("Pull"),
+		primary_action(values) {
+			const start_date = moment(values.end_date, DATE_FORMAT)
+				.subtract(PULL_WINDOW_HOURS, "hours")
+				.format(DATE_FORMAT);
+			dialog.hide();
+			frappe.call({
+				method:
+					"frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.bulk_pull_transactions",
+				args: {
+					settings_names: selected,
+					start_date: start_date,
+					end_date: values.end_date,
+				},
+				freeze: true,
+				freeze_message: __("Queueing pull..."),
+				callback: function (r) {
+					if (r.message) {
+						frappe.show_alert({
+							message: r.message.message,
+							indicator: r.message.status === "error" ? "red" : "blue",
+						});
+					}
+				},
+			});
+		},
+	});
+	dialog.show();
+	render_range();
+}
+
+function bulk_register(selected) {
+	// Preview first. Registration cannot be undone from our side: Safaricom
+	// rejects re-registration with "Shortcode already Registered!", so a wrong
+	// CallBackURL baked in here is permanent. Show it before committing.
+	frappe.call({
+		method:
+			"frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.bulk_register_pull_transactions",
+		args: { settings_names: selected, dry_run: 1 },
+		callback: function (r) {
+			if (!r.message || r.message.status === "error") {
+				frappe.msgprint(r.message ? r.message.message : __("Nothing to register."));
+				return;
+			}
+
+			const msg = r.message;
+			frappe.confirm(
+				__(
+					"Register <b>{0}</b> shortcode(s) for Pull Transactions?<br><br>" +
+						"Callback URL that will be sent to Safaricom:<br><code>{1}</code>" +
+						"<br><br><b>This cannot be undone.</b> Safaricom rejects re-registration, " +
+						"so make sure you are on the correct production domain before continuing.",
+					[msg.count, frappe.utils.escape_html(msg.callback_url)]
+				),
+				() => {
+					frappe.call({
+						method:
+							"frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.mpesa_settings.bulk_register_pull_transactions",
+						args: { settings_names: selected, dry_run: 0 },
+						freeze: true,
+						freeze_message: __("Queueing registration..."),
+						callback: function (res) {
+							if (res.message) {
+								frappe.show_alert({
+									message: res.message.message,
+									indicator: "blue",
+								});
+							}
+						},
+					});
+				}
+			);
+		},
+	});
+}
+
+frappe.realtime.on("mpesa_bulk_pull_registration_complete", function (data) {
+	frappe.msgprint({
+		title: data.title || __("Bulk Pull Registration Complete"),
+		message: data.message,
+		indicator: data.status === "success" ? "green" : "orange",
+	});
+});
+
+frappe.realtime.on("mpesa_bulk_pull_complete", function (data) {
+	frappe.msgprint({
+		title: data.title || __("Bulk Pull Complete"),
+		message: data.message,
+		indicator: data.status === "success" ? "green" : "orange",
+	});
+	if (cur_list && cur_list.doctype === "Mpesa Settings") {
+		cur_list.refresh();
+	}
+});

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/test_mpesa_settings.py
@@ -402,6 +402,84 @@ class TestMpesaSettings(unittest.TestCase):
         self.assertEqual(count, 1)
         frappe.db.delete("Mpesa C2B Payment Register", {"transid": unique_txn_id})
 
+    def _capture_pull_realtime(self, response):
+        """Run pull_transaction_on_success and return the realtime message it published."""
+        from unittest.mock import patch
+
+        from frappe_mpsa_payments.frappe_mpsa_payments.api.mpesa_response_handler import (
+            pull_transaction_on_success,
+        )
+
+        published = {}
+
+        def fake_publish(*args, **kwargs):
+            if kwargs.get("event") == "mpesa_pull_transaction_complete":
+                published.update(kwargs.get("message") or {})
+
+        with patch(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.mpesa_response_handler.frappe.publish_realtime",
+            side_effect=fake_publish,
+        ):
+            pull_transaction_on_success(
+                response=response,
+                document_name="_Test",
+                settings_name="_Test",
+                integration_request=None,
+            )
+        return published
+
+    def test_pull_transaction_1001_is_not_reported_as_success(self):
+        """1001 arrives as HTTP 200 and must not read as a successful import.
+
+        Regression: it used to fall through to the import loop, find no
+        "Response" key, and publish "0 record(s) imported" - making an
+        unprovisioned shortcode indistinguishable from a quiet window.
+        """
+        published = self._capture_pull_realtime(
+            {
+                "ResponseCode": "1001",
+                "ResponseMessage": "No records found or Organization Name not available",
+            }
+        )
+
+        self.assertEqual(published.get("status"), "warning")
+        self.assertEqual(published.get("response_code"), "1001")
+        self.assertIn("1001", published.get("message", ""))
+        self.assertNotIn("record(s) imported", published.get("message", ""))
+
+        self.assertEqual(
+            frappe.db.get_value("Mpesa Settings", "_Test", "last_pull_status"),
+            "No Data",
+        )
+        self.assertEqual(
+            frappe.db.get_value("Mpesa Settings", "_Test", "last_pull_response_code"),
+            "1001",
+        )
+
+    def test_pull_transaction_other_error_code_is_reported_as_error(self):
+        published = self._capture_pull_realtime(
+            {"ResponseCode": "500.003.02", "ResponseMessage": "Internal server error"}
+        )
+
+        self.assertEqual(published.get("status"), "error")
+        self.assertEqual(published.get("count"), 0)
+        self.assertEqual(
+            frappe.db.get_value("Mpesa Settings", "_Test", "last_pull_status"), "Error"
+        )
+
+    def test_pull_transaction_1000_with_empty_response_still_reports_zero(self):
+        """A genuinely quiet window is still a success, just with nothing to import."""
+        published = self._capture_pull_realtime(
+            {"ResponseCode": "1000", "ResponseMessage": "Success", "Response": []}
+        )
+
+        self.assertIn("0 record(s) imported", published.get("message", ""))
+        self.assertEqual(published.get("count"), 0)
+        self.assertEqual(
+            frappe.db.get_value("Mpesa Settings", "_Test", "last_pull_status"),
+            "Success",
+        )
+
     def test_processing_of_only_one_succes_callback_payload(self):
         mpesa_account = frappe.db.get_value(
             "Payment Gateway Account",


### PR DESCRIPTION
fix: show when pull transactions actually fail, add bulk actions
Safaricom returns HTTP 200 even when a pull fails, so a 1001 response was reported as "0 record(s) imported". That hid failed pulls for child paybill accounts (only HO worked).

- Check ResponseCode. Anything not 1000 is logged and shown as what it is.
- Mpesa Settings now stores last pull result and registration state, both in the list view.
- Retry connection timeouts 3 times instead of losing the window.
- Mpesa Settings >  List view - includes Bulk Register + Pull Transactions.
- Bulk Pull Transactions from the list, with a date range. Combined into result summary (instead of popup per mpesa account)