### PR TITLE
Clear the remaining eslint errors in B2C Payment Disbursement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
 	"root": true,
 	"globals": {
 		"frappe": true,
+		"erpnext": true,
 		"Vue": true,
 		"SetVueGlobals": true,
 		"__": true,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/process_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/process_request.py
@@ -1,5 +1,7 @@
-from typing import Optional, Union, Callable, Literal
+from typing import Callable, Literal, Optional, Union
+
 from ..connectors.connectors import MpesaConnector
+
 
 def process_request(
     endpoint: str,
@@ -52,4 +54,6 @@ def process_request(
         builder.on_error(error_callback)
 
     # Make the remote API call
-    return builder.make_remote_call(doctype=doctype, document_name=document_name, retrying=retrying)
+    return builder.make_remote_call(
+        doctype=doctype, document_name=document_name, retrying=retrying
+    )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/test_payment_entry.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/test_payment_entry.py
@@ -1,12 +1,13 @@
-import frappe
 from frappe.tests.utils import FrappeTestCase
+
 from frappe_mpsa_payments.frappe_mpsa_payments.api.payment_entry import (
+    get_available_pos_profiles,
     get_outstanding_invoices,
     get_unallocated_payments,
     process_pos_payment,
-    get_available_pos_profiles,
     set_paid_amount_and_received_amount,
 )
+
 
 class TestPaymentFunctions(FrappeTestCase):
     def test_get_outstanding_invoices(self):
@@ -15,7 +16,9 @@ class TestPaymentFunctions(FrappeTestCase):
         customer = "Test Customer"
         pos_profile_name = "Test POS Profile"
 
-        invoices = get_outstanding_invoices(company, currency, customer, pos_profile_name)
+        invoices = get_outstanding_invoices(
+            company, currency, customer, pos_profile_name
+        )
 
         # Assert the result
         self.assertTrue(isinstance(invoices, list))
@@ -27,7 +30,9 @@ class TestPaymentFunctions(FrappeTestCase):
         mode_of_payment = "Cash"
 
         # Call the function
-        unallocated_payments = get_unallocated_payments(customer, company, currency, mode_of_payment)
+        unallocated_payments = get_unallocated_payments(
+            customer, company, currency, mode_of_payment
+        )
 
         # Assert the result
         self.assertTrue(isinstance(unallocated_payments, list))
@@ -38,22 +43,20 @@ class TestPaymentFunctions(FrappeTestCase):
             "currency": "KES",
             "customer": "Test Customer",
             "pos_opening_shift_name": "Test Opening Shift",
- "pos_profile": {
-        "name": "Test POS Profile",
-        "custom_allow_make_new_payments": 1,
-        "custom_allow_make_new_invoices": 1,
-        "custom_use_pos_payments": 1
-    },            "pos_profile_name": "Test POS Profile",
-            
+            "pos_profile": {
+                "name": "Test POS Profile",
+                "custom_allow_make_new_payments": 1,
+                "custom_allow_make_new_invoices": 1,
+                "custom_use_pos_payments": 1,
+            },
+            "pos_profile_name": "Test POS Profile",
             "selected_invoices": [],
             "selected_payments": [],
             "selected_mpesa_payments": [],
             "total_selected_invoices": 0,
             "total_selected_payments": 0,
             "total_selected_mpesa_payments": 0,
-            "payment_methods": [
-                {"mode_of_payment": "Cash", "amount": 50.00}
-            ],
+            "payment_methods": [{"mode_of_payment": "Cash", "amount": 50.00}],
             "total_payment_methods": 50.00,
         }
 
@@ -71,14 +74,23 @@ class TestPaymentFunctions(FrappeTestCase):
 
     def test_set_paid_amount_and_received_amount(self):
         party_account_currency = "KES"
-        bank = {"account_currency": "KES", "bank_currency": "KES", "conversion_rate": 1.0}
+        bank = {
+            "account_currency": "KES",
+            "bank_currency": "KES",
+            "conversion_rate": 1.0,
+        }
         outstanding_amount = 100.00
         payment_type = "Receive"
         bank_amount = None
         conversion_rate = 1.0
 
         paid_amount, received_amount = set_paid_amount_and_received_amount(
-            party_account_currency, bank, outstanding_amount, payment_type, bank_amount, conversion_rate
+            party_account_currency,
+            bank,
+            outstanding_amount,
+            payment_type,
+            bank_amount,
+            conversion_rate,
         )
 
         self.assertEqual(paid_amount, 100.00)

--- a/frappe_mpsa_payments/frappe_mpsa_payments/connectors/connectors.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/connectors/connectors.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
-from typing import Callable, Literal, Optional, Union
-from urllib import parse
-from frappe.model.document import Document
-
-from datetime import datetime, timedelta
-
-import requests
-from requests.auth import HTTPBasicAuth
-import frappe
-from frappe.integrations.utils import create_request_log
 import base64
+from datetime import datetime, timedelta
+from typing import Callable, Literal, Optional, Union
+
+import frappe
+import requests
+from frappe.integrations.utils import create_request_log
+from frappe.model.document import Document
+from requests.auth import HTTPBasicAuth
+
 
 # Remote error handler for Mpesa
 def on_mpesa_error(data, url, doctype, document_name):
     error_msg = f"Remote error at {url} for {doctype} {document_name}: {data}"
-    frappe.log_error(title="Mpesa Error", message=error_msg, reference_doctype=doctype, reference_name=document_name)
+    frappe.log_error(
+        title="Mpesa Error",
+        message=error_msg,
+        reference_doctype=doctype,
+        reference_name=document_name,
+    )
+
 
 # Custom integration request updater
 def update_integration_request(
@@ -30,10 +35,13 @@ def update_integration_request(
         doc.error = error if doc.error in (None, "null") else (doc.error + "\n" + error)
 
     if output:
-        doc.output = output if doc.output in (None, "null") else (doc.output + "\n" + output)
+        doc.output = (
+            output if doc.output in (None, "null") else (doc.output + "\n" + output)
+        )
 
     doc.status = status
     doc.save(ignore_permissions=True)
+
 
 # Observer for error handling
 class ErrorObserver:
@@ -41,11 +49,21 @@ class ErrorObserver:
         if notifier.error:
             name = getattr(notifier.integration_request, "name", None)
             if name:
-                update_integration_request(name, status="Failed", error=str(notifier.error))
-            frappe.log_error(title="Mpesa Fatal Error", message=str(notifier.error),
-                             reference_doctype=notifier.doctype,
-                             reference_name=notifier.document_name)
-            frappe.throw("A Fatal Error occurred. Check the Error Log.", notifier.error, title="Mpesa Fatal Error")
+                update_integration_request(
+                    name, status="Failed", error=str(notifier.error)
+                )
+            frappe.log_error(
+                title="Mpesa Fatal Error",
+                message=str(notifier.error),
+                reference_doctype=notifier.doctype,
+                reference_name=notifier.document_name,
+            )
+            frappe.throw(
+                "A Fatal Error occurred. Check the Error Log.",
+                notifier.error,
+                title="Mpesa Fatal Error",
+            )
+
 
 # Base builder class
 class BaseMpesaConnector:
@@ -60,8 +78,8 @@ class BaseMpesaConnector:
         for observer in self._observers:
             observer.update(self)
 
+
 class MpesaConnector(BaseMpesaConnector):
-    
     def __init__(self, settings_name: str):
         super().__init__()
         self.settings_name = settings_name
@@ -93,7 +111,11 @@ class MpesaConnector(BaseMpesaConnector):
 
     def _initialize_settings(self):
         settings = self._get_mpesa_settings()
-        self._base_url = "https://sandbox.safaricom.co.ke" if settings["sandbox"] else "https://api.safaricom.co.ke"
+        self._base_url = (
+            "https://sandbox.safaricom.co.ke"
+            if settings["sandbox"]
+            else "https://api.safaricom.co.ke"
+        )
 
     def _is_token_valid(self) -> bool:
         settings = self._get_mpesa_settings()
@@ -104,16 +126,15 @@ class MpesaConnector(BaseMpesaConnector):
     def _update_token(self, token: str, expires_in: int):
         token_expiry = datetime.now() + timedelta(seconds=int(expires_in))
         frappe.db.set_value(
-            "Mpesa Settings", 
-            self.settings_name, 
+            "Mpesa Settings",
+            self.settings_name,
             {
                 "access_token": token,
                 "expires_in": int(expires_in),
-                "token_expiry": token_expiry
-            }
+                "token_expiry": token_expiry,
+            },
         )
         frappe.db.commit()
-
 
     def _set_timeout(self, seconds: int):
         self._timeout = seconds
@@ -126,7 +147,7 @@ class MpesaConnector(BaseMpesaConnector):
             url = f"{self._base_url}/oauth/v1/generate?grant_type=client_credentials"
             auth_string = f"{s['consumer_key']}:{s['consumer_secret']}"
             encoded_auth = base64.b64encode(auth_string.encode()).decode()
-            
+
             self.integration_request = create_request_log(
                 data={"grant_type": "client_credentials"},
                 request_description="Mpesa OAuth Token Authentication",
@@ -137,24 +158,22 @@ class MpesaConnector(BaseMpesaConnector):
                 reference_docname=self.settings_name,
                 reference_doctype="Mpesa Settings",
             )
-            r = requests.get(url, auth=HTTPBasicAuth(s["consumer_key"], s["consumer_secret"]))
+            r = requests.get(
+                url, auth=HTTPBasicAuth(s["consumer_key"], s["consumer_secret"])
+            )
             r.raise_for_status()
             data = r.json()
             self._update_token(data["access_token"], data["expires_in"])
-            
+
             update_integration_request(
-                self.integration_request.name, 
-                status="Completed", 
-                output=str(data)
+                self.integration_request.name, status="Completed", output=str(data)
             )
-            
+
             return data["access_token"]
         except Exception as e:
-            if hasattr(self, 'integration_request') and self.integration_request:
+            if hasattr(self, "integration_request") and self.integration_request:
                 update_integration_request(
-                    self.integration_request.name, 
-                    status="Failed", 
-                    error=str(e)
+                    self.integration_request.name, status="Failed", error=str(e)
                 )
             self.error = e
             self.notify()
@@ -171,9 +190,18 @@ class MpesaConnector(BaseMpesaConnector):
         headers.update(self._custom_headers)
         return headers
 
-    def make_remote_call(self, doctype=None, document_name=None, retrying=False, skip_integration_request=False):
+    def make_remote_call(
+        self,
+        doctype=None,
+        document_name=None,
+        retrying=False,
+        skip_integration_request=False,
+    ):
         if not all([self._endpoint, self._method, self._success_callback]):
-            frappe.throw("Missing required parameters (endpoint, method, callbacks).", frappe.MandatoryError)
+            frappe.throw(
+                "Missing required parameters (endpoint, method, callbacks).",
+                frappe.MandatoryError,
+            )
 
         self._initialize_settings()
         self._url = f"{self._base_url}/{self._endpoint.lstrip('/')}"
@@ -194,7 +222,9 @@ class MpesaConnector(BaseMpesaConnector):
                     limit=1,
                 )
                 if existing_request:
-                    self.integration_request = frappe.get_doc("Integration Request", existing_request[0].name)
+                    self.integration_request = frappe.get_doc(
+                        "Integration Request", existing_request[0].name
+                    )
                 else:
                     self.integration_request = create_request_log(
                         data=self._payload,
@@ -236,10 +266,18 @@ class MpesaConnector(BaseMpesaConnector):
     def _send_request(self) -> requests.Response:
         headers = self._get_authenticated_headers()
         method_map = {
-            "GET": lambda: requests.get(self._url, headers=headers, params=self._payload, timeout=self._timeout),
-            "POST": lambda: requests.post(self._url, json=self._payload, headers=headers, timeout=self._timeout),
-            "PATCH": lambda: requests.patch(self._url, json=self._payload, headers=headers, timeout=self._timeout),
-            "PUT": lambda: requests.put(self._url, json=self._payload, headers=headers, timeout=self._timeout),
+            "GET": lambda: requests.get(
+                self._url, headers=headers, params=self._payload, timeout=self._timeout
+            ),
+            "POST": lambda: requests.post(
+                self._url, json=self._payload, headers=headers, timeout=self._timeout
+            ),
+            "PATCH": lambda: requests.patch(
+                self._url, json=self._payload, headers=headers, timeout=self._timeout
+            ),
+            "PUT": lambda: requests.put(
+                self._url, json=self._payload, headers=headers, timeout=self._timeout
+            ),
         }
 
         if self._method in {"PATCH", "PUT"} and self._payload and "id" in self._payload:
@@ -250,29 +288,70 @@ class MpesaConnector(BaseMpesaConnector):
         return method_map[self._method]()
 
     def _handle_success(self, data):
-        self._success_callback(response=data, payload=self._payload, document_name=self.document_name, doctype=self.doctype, integration_request=self.integration_request, settings_name=self.settings_name)
-        update_integration_request(self.integration_request.name, status="Completed", output=str(data))
+        self._success_callback(
+            response=data,
+            payload=self._payload,
+            document_name=self.document_name,
+            doctype=self.doctype,
+            integration_request=self.integration_request,
+            settings_name=self.settings_name,
+        )
+        update_integration_request(
+            self.integration_request.name, status="Completed", output=str(data)
+        )
 
     def _handle_error(self, data):
-        update_integration_request(self.integration_request.name, status="Failed", error=str(data))
+        update_integration_request(
+            self.integration_request.name, status="Failed", error=str(data)
+        )
         if self._error_callback:
-            self._error_callback(response=data, payload=self._payload, document_name=self.document_name, doctype=self.doctype, integration_request=self.integration_request, settings_name=self.settings_name)
+            self._error_callback(
+                response=data,
+                payload=self._payload,
+                document_name=self.document_name,
+                doctype=self.doctype,
+                integration_request=self.integration_request,
+                settings_name=self.settings_name,
+            )
         else:
-            on_mpesa_error(data, url=self._url, doctype=self.doctype, document_name=self.document_name)
+            on_mpesa_error(
+                data,
+                url=self._url,
+                doctype=self.doctype,
+                document_name=self.document_name,
+            )
 
-    def set_headers(self, headers: dict): self._custom_headers.update(headers); return self
-    def set_endpoint(self, endpoint: str): self._endpoint = endpoint; return self
-    def set_payload(self, payload: dict): self._payload = payload; return self
-    def set_method(self, method): self._method = method; return self
-    def on_success(self, callback: Callable): self._success_callback = callback; return self
-    def on_error(self, callback: Callable): self._error_callback = callback; return self
-    def describe(self, description: str): self._request_description = description; return self
-    
-    def reuse_existing_request(self, flag: bool = True): 
-        self._reuse_existing_integration_request = flag
+    def set_headers(self, headers: dict):
+        self._custom_headers.update(headers)
         return self
 
+    def set_endpoint(self, endpoint: str):
+        self._endpoint = endpoint
+        return self
 
+    def set_payload(self, payload: dict):
+        self._payload = payload
+        return self
+
+    def set_method(self, method):
+        self._method = method
+        return self
+
+    def on_success(self, callback: Callable):
+        self._success_callback = callback
+        return self
+
+    def on_error(self, callback: Callable):
+        self._error_callback = callback
+        return self
+
+    def describe(self, description: str):
+        self._request_description = description
+        return self
+
+    def reuse_existing_request(self, flag: bool = True):
+        self._reuse_existing_integration_request = flag
+        return self
 
 
 def get_response_data(response: requests.Response) -> Optional[Union[dict, str, bytes]]:

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/__init__.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/__init__.py
@@ -1,4 +1,3 @@
-
 import frappe
 from frappe.utils import logger
 

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
@@ -3,11 +3,10 @@
 
 const HAS_ERPNEXT = frappe.boot?.app_data?.some((app) => app.app_name === "erpnext");
 
-if (!HAS_ERPNEXT) {
-	return;
-}
-
-frappe.ui.form.on("B2C Payment Disbursement", {
+// Frappe runs doctype scripts through `new Function(...)`, so a bare top-level
+// return works at runtime - but the file is linted as a module, where it is a
+// syntax error. Hold the handlers and register them behind the guard instead.
+const B2C_HANDLERS = {
 	onload: function (frm) {
 		frm.ignore_doctypes_on_cancel_all = [
 			"Employee Advance",
@@ -516,7 +515,7 @@ frappe.ui.form.on("B2C Payment Disbursement", {
 			},
 		]);
 
-		btn_text = "Get Outstanding References";
+		const btn_text = "Get Outstanding References";
 
 		frappe.prompt(
 			fields,
@@ -595,7 +594,6 @@ frappe.ui.form.on("B2C Payment Disbursement", {
 			to_posting_date: filters.to_posting_date,
 			from_due_date: filters.from_due_date,
 			to_due_date: filters.to_due_date,
-			outstanding_amt_greater_than: filters.outstanding_amt_greater_than,
 			outstanding_amt_greater_than: filters.outstanding_amt_greater_than,
 		};
 
@@ -689,7 +687,11 @@ frappe.ui.form.on("B2C Payment Disbursement", {
 			},
 		});
 	},
-});
+};
+
+if (HAS_ERPNEXT) {
+	frappe.ui.form.on("B2C Payment Disbursement", B2C_HANDLERS);
+}
 
 function generateUUIDv4() {
 	// Generates a uuid4 string conforming to RFC standards

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.py
@@ -496,7 +496,6 @@ class B2CPaymentDisbursement(Document):
         from erpnext.accounts.doctype.payment_entry.payment_entry import (
             get_outstanding_reference_documents as original_get_outstanding_reference_documents,
         )
-
         from erpnext.accounts.party import get_party_account
 
         party_type = args.get("party_type")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/config.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/config.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import List, Dict, Callable, Optional
+from typing import Callable, Dict, List, Optional
+
 
 @dataclass
 class DoctypeConfig:
@@ -10,23 +11,39 @@ class DoctypeConfig:
     payable_amount_calc: Optional[Callable[[Dict], float]] = None
     invoice_amount_field: str = "grand_total"
 
+
 # Configuration for different document types
 DOCTYPE_CONFIGS = {
     "Employee Advance": DoctypeConfig(
-        fields=["name", "posting_date", "employee", "currency", "advance_amount",
-                "paid_amount", "pending_amount", "claimed_amount"],
+        fields=[
+            "name",
+            "posting_date",
+            "employee",
+            "currency",
+            "advance_amount",
+            "paid_amount",
+            "pending_amount",
+            "claimed_amount",
+        ],
         date_field="posting_date",
         additional_filters={},
         payable_amount_calc=lambda e: (e.advance_amount or 0) - (e.paid_amount or 0),
-        invoice_amount_field="advance_amount"
+        invoice_amount_field="advance_amount",
     ),
     "Expense Claim": DoctypeConfig(
-        fields=["name", "posting_date", "employee", "grand_total",
-                "total_claimed_amount", "total_amount_reimbursed"],
+        fields=[
+            "name",
+            "posting_date",
+            "employee",
+            "grand_total",
+            "total_claimed_amount",
+            "total_amount_reimbursed",
+        ],
         date_field="posting_date",
         additional_filters={"approval_status": "Approved", "status": "Unpaid"},
-        payable_amount_calc=lambda e: (e.total_claimed_amount or 0) - (e.total_amount_reimbursed or 0),
-        invoice_amount_field="total_claimed_amount"
+        payable_amount_calc=lambda e: (e.total_claimed_amount or 0)
+        - (e.total_amount_reimbursed or 0),
+        invoice_amount_field="total_claimed_amount",
     ),
     "Purchase Invoice": DoctypeConfig(
         fields=[],
@@ -34,7 +51,7 @@ DOCTYPE_CONFIGS = {
         additional_filters={},
         use_erpnext_function=True,
         payable_amount_calc=lambda e: e.get("outstanding_amount", 0),
-        invoice_amount_field="invoice_amount"
+        invoice_amount_field="invoice_amount",
     ),
     "Purchase Order": DoctypeConfig(
         fields=[],
@@ -42,20 +59,38 @@ DOCTYPE_CONFIGS = {
         additional_filters={},
         use_erpnext_function=True,
         payable_amount_calc=lambda e: e.get("outstanding_amount", 0),
-        invoice_amount_field="invoice_amount"
+        invoice_amount_field="invoice_amount",
     ),
     "Salary Slip": DoctypeConfig(
-        fields=["name", "posting_date", "employee", "net_pay", "currency", "journal_entry", "base_rounded_total", "payroll_entry"],
+        fields=[
+            "name",
+            "posting_date",
+            "employee",
+            "net_pay",
+            "currency",
+            "journal_entry",
+            "base_rounded_total",
+            "payroll_entry",
+        ],
         date_field="posting_date",
         additional_filters={},
-        payable_amount_calc=lambda e: e.get("base_rounded_total") or e.get("rounded_total") or e.get("outstanding_amount") or 0,
-        invoice_amount_field="net_pay"
+        payable_amount_calc=lambda e: e.get("base_rounded_total")
+        or e.get("rounded_total")
+        or e.get("outstanding_amount")
+        or 0,
+        invoice_amount_field="net_pay",
     ),
     "Loan": DoctypeConfig(
-        fields=["name", "applicant_type", "applicant", "loan_amount", "disbursed_amount"],
+        fields=[
+            "name",
+            "applicant_type",
+            "applicant",
+            "loan_amount",
+            "disbursed_amount",
+        ],
         date_field="posting_date",
         additional_filters={"status": ["in", ["Sanctioned", "Partially Disbursed"]]},
         payable_amount_calc=lambda e: (e.loan_amount or 0) - (e.disbursed_amount or 0),
-        invoice_amount_field="loan_amount"
-    )
+        invoice_amount_field="loan_amount",
+    ),
 }

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/test_b2c_payment_disbursement.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/test_b2c_payment_disbursement.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2024, Navari Limited and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
+
 from .b2c_payment_disbursement import B2CPaymentDisbursement
-from unittest.mock import patch
 
 
 class TestB2CPaymentDisbursement(FrappeTestCase):
@@ -260,11 +262,11 @@ class TestB2CPaymentDisbursement(FrappeTestCase):
         self.payment_disbursement.posting_date = "2024-06-01"
         self.payment_disbursement.source_exchange_rate = 1.0
         self.payment_disbursement.paid_amount = 100
-        
+
         # Patch frappe.get_cached_value
         original_get_cached_value = frappe.get_cached_value
         frappe.get_cached_value = lambda doctype, name, field: "KES"
-        
+
         try:
             self.payment_disbursement.set_missing_values()
             self.assertEqual(self.payment_disbursement.company_currency, "KES")
@@ -272,19 +274,21 @@ class TestB2CPaymentDisbursement(FrappeTestCase):
             frappe.get_cached_value = original_get_cached_value
 
     @patch("frappe.get_cached_value")
-    def test_set_missing_values_does_not_set_company_currency_if_exists(self, mock_get_cached_value):
+    def test_set_missing_values_does_not_set_company_currency_if_exists(
+        self, mock_get_cached_value
+    ):
         """Test that set_missing_values does not overwrite company_currency if it already exists."""
         self.payment_disbursement.company_currency = "USD"
         self.payment_disbursement.paid_from_account_currency = "KES"
         self.payment_disbursement.posting_date = "2024-06-01"
         self.payment_disbursement.source_exchange_rate = 1.0
         self.payment_disbursement.paid_amount = 100
-        
+
         # Mock get_cached_value to return a different currency
         mock_get_cached_value.return_value = "EUR"
-        
+
         self.payment_disbursement.set_missing_values()
-        
+
         # Assert that company_currency is still USD
         self.assertEqual(self.payment_disbursement.company_currency, "USD")
 
@@ -296,29 +300,31 @@ class TestB2CPaymentDisbursement(FrappeTestCase):
         self.payment_disbursement.company_currency = "USD"
         self.payment_disbursement.posting_date = "2024-06-01"
         self.payment_disbursement.paid_amount = 100
-        
+
         # Mock get_cached_value to return a valid exchange rate
         mock_get_cached_value.return_value = 110.0
-        
+
         self.payment_disbursement.set_missing_values()
-        
+
         # Assert that source_exchange_rate is set correctly
         self.assertEqual(self.payment_disbursement.source_exchange_rate, 110.0)
 
     @patch("frappe.get_cached_value")
-    def test_set_missing_values_does_not_set_source_exchange_rate_if_exists(self, mock_get_cached_value):
+    def test_set_missing_values_does_not_set_source_exchange_rate_if_exists(
+        self, mock_get_cached_value
+    ):
         """Test that set_missing_values does not overwrite source_exchange_rate if it already exists."""
         self.payment_disbursement.source_exchange_rate = 1.5
         self.payment_disbursement.paid_from_account_currency = "KES"
         self.payment_disbursement.company_currency = "USD"
         self.payment_disbursement.posting_date = "2024-06-01"
         self.payment_disbursement.paid_amount = 100
-        
+
         # Mock get_cached_value to return a different exchange rate
         mock_get_cached_value.return_value = 2.0
-        
+
         self.payment_disbursement.set_missing_values()
-        
+
         # Assert that source_exchange_rate is still 1.5
         self.assertEqual(self.payment_disbursement.source_exchange_rate, 1.5)
 
@@ -331,21 +337,26 @@ class TestB2CPaymentDisbursement(FrappeTestCase):
             security_credential="Test Credential",
             business_shortcode="123456",
             consumer_key="CKEY",
-            consumer_secret="CSECRET"
+            consumer_secret="CSECRET",
         )
-        
+
         # Mock the get_doc call to return the mock setting
         self.payment_disbursement.mpesa_setting = "Test Gateway"
         mock_get_doc.return_value = mock_setting
 
         result = self.payment_disbursement._get_mpesa_settings()
-        
-        self.assertEqual(result, mock_setting) # Assert that the returned document matches the mock
-        
+
+        self.assertEqual(
+            result, mock_setting
+        )  # Assert that the returned document matches the mock
+
         # Assert that get_doc was called with the correct parameters
         mock_get_doc.assert_called_once_with(
             "Mpesa Settings",
-            {"payment_gateway_name": "Test Gateway", "api_type": "MPesa B2C (Business to Customer)"},
+            {
+                "payment_gateway_name": "Test Gateway",
+                "api_type": "MPesa B2C (Business to Customer)",
+            },
             [
                 "name",
                 "initiator_name",
@@ -359,7 +370,9 @@ class TestB2CPaymentDisbursement(FrappeTestCase):
 
     @patch("frappe.get_doc")
     @patch("frappe.throw")
-    @patch("frappe_mpsa_payments.frappe_mpsa_payments.doctype.b2c_payment_disbursement.b2c_payment_disbursement.app_logger")
+    @patch(
+        "frappe_mpsa_payments.frappe_mpsa_payments.doctype.b2c_payment_disbursement.b2c_payment_disbursement.app_logger"
+    )
     def test_get_mpesa_settings_not_found(self, mock_logger, mock_throw, mock_get_doc):
         """Test that _get_mpesa_settings throws and logs error if settings not found."""
         self.payment_disbursement.mpesa_setting = "Missing Gateway"

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/test_b2c_payment_disbursement_reference.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/test_b2c_payment_disbursement_reference.py
@@ -3,8 +3,11 @@
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from .b2c_payment_disbursement_reference import sanitise_phone_number
-from .b2c_payment_disbursement_reference import is_valid_receiver_contact
+
+from .b2c_payment_disbursement_reference import (
+    is_valid_receiver_contact,
+    sanitise_phone_number,
+)
 
 
 class TestB2CPaymentDisbursementReference(FrappeTestCase):

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/test_mpesa_c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/test_mpesa_c2b_payment_register.py
@@ -6,4 +6,4 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestMpesaC2BPaymentRegister(FrappeTestCase):
-	pass
+    pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register_url/mpesa_c2b_payment_register_url.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register_url/mpesa_c2b_payment_register_url.js
@@ -3,6 +3,6 @@
 
 // frappe.ui.form.on("Mpesa C2B Payment Register URL", {
 // 	refresh(frm) {
-       
+
 // 	},
 // });

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register_url/test_mpesa_c2b_payment_register_url.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register_url/test_mpesa_c2b_payment_register_url.py
@@ -1,93 +1,100 @@
 # Copyright (c) 2024, Navari Limited and Contributors
 # See license.txt
 
+from unittest.mock import Mock, patch
+
 import frappe
-import unittest
-from unittest.mock import patch, Mock
-from frappe.utils import get_request_site_address
-from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import get_token
-from frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.test_mpesa_settings import TestMpesaSettings
-from frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_c2b_payment_register_url.mpesa_c2b_payment_register_url import MpesaC2BPaymentRegisterURL
+
+from frappe_mpsa_payments.frappe_mpsa_payments.doctype.mpesa_settings.test_mpesa_settings import (
+    TestMpesaSettings,
+)
 
 
 def create_mpesa_setting_doc():
-	if not frappe.db.exists("Mpesa Settings", "Test Mpesa Settings"):
-		mpesa_settings1 = frappe.new_doc("Mpesa Settings")
-		mpesa_settings1.payment_gateway_name = "Test Mpesa Settings"
-		mpesa_settings1.mpesa_environment = "sandbox"
-		mpesa_settings1.consumer_key = "xMPJE16CDdAfBmOWvbqRsqlioAcQT77sWw2JD9OcceHp8fHv"
-		mpesa_settings1.consumer_secret = "NDXh2tdne9bMrnOEZXd8gQZiHPMWSpfWc2YXBLGQxiz66OGbcn5S79DKakgt3LQN"
-		mpesa_settings1.shortcode = "123456"
-		mpesa_settings1.business_shortcode = "123456"
-		mpesa_settings1.online_passkey = "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919"
-		mpesa_settings1.till_number = "123456"
-		mpesa_settings1.initiator_name = "test_initiator_name"
-		mpesa_settings1.transaction_limit = 1000
-		mpesa_settings1.security_credential = "test_security_credential"
-		mpesa_settings1.sandbox=1
-		mpesa_settings1.save()
-		
+    if not frappe.db.exists("Mpesa Settings", "Test Mpesa Settings"):
+        mpesa_settings1 = frappe.new_doc("Mpesa Settings")
+        mpesa_settings1.payment_gateway_name = "Test Mpesa Settings"
+        mpesa_settings1.mpesa_environment = "sandbox"
+        mpesa_settings1.consumer_key = (
+            "xMPJE16CDdAfBmOWvbqRsqlioAcQT77sWw2JD9OcceHp8fHv"
+        )
+        mpesa_settings1.consumer_secret = (
+            "NDXh2tdne9bMrnOEZXd8gQZiHPMWSpfWc2YXBLGQxiz66OGbcn5S79DKakgt3LQN"
+        )
+        mpesa_settings1.shortcode = "123456"
+        mpesa_settings1.business_shortcode = "123456"
+        mpesa_settings1.online_passkey = (
+            "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919"
+        )
+        mpesa_settings1.till_number = "123456"
+        mpesa_settings1.initiator_name = "test_initiator_name"
+        mpesa_settings1.transaction_limit = 1000
+        mpesa_settings1.security_credential = "test_security_credential"
+        mpesa_settings1.sandbox = 1
+        mpesa_settings1.save()
+
+
 def create_mpesa_c2b_payment_register_url_doc():
-	if not frappe.db.exists("Mpesa C2B Payment Register URL", "Test Mpesa C2B Payment Register URL"):
-		mpesa_c2b_payment_register_url = frappe.new_doc("Mpesa C2B Payment Register URL")
-		mpesa_c2b_payment_register_url.business_shortcode = "123456"
-		mpesa_c2b_payment_register_url.mpesa_settings = "Test Mpesa Settings"
-		mpesa_c2b_payment_register_url.register_status = "Success"
-		mpesa_c2b_payment_register_url.till_number = "123456"
-		mpesa_c2b_payment_register_url.mode_of_payment = "Cash"
-		mpesa_c2b_payment_register_url.company = "Pharma Express du 30 juin"
-		mpesa_c2b_payment_register_url.save()
-	
+    if not frappe.db.exists(
+        "Mpesa C2B Payment Register URL", "Test Mpesa C2B Payment Register URL"
+    ):
+        mpesa_c2b_payment_register_url = frappe.new_doc(
+            "Mpesa C2B Payment Register URL"
+        )
+        mpesa_c2b_payment_register_url.business_shortcode = "123456"
+        mpesa_c2b_payment_register_url.mpesa_settings = "Test Mpesa Settings"
+        mpesa_c2b_payment_register_url.register_status = "Success"
+        mpesa_c2b_payment_register_url.till_number = "123456"
+        mpesa_c2b_payment_register_url.mode_of_payment = "Cash"
+        mpesa_c2b_payment_register_url.company = "Pharma Express du 30 juin"
+        mpesa_c2b_payment_register_url.save()
+
+
 class TestMpesaC2BPaymentRegisterURL(TestMpesaSettings):
-	def setUp(self):
-		create_mpesa_setting_doc()
-		create_mpesa_c2b_payment_register_url_doc()
-  
-	def tearDown(self):
-		# Delete the Mpesa Settings document
-		mpesa_settings_doc = frappe.get_doc("Mpesa C2B Payment Register URL", "Test Mpesa Settings")
-		if mpesa_settings_doc:
-			frappe.delete_doc("Mpesa C2B Payment Register URL", "Test Mpesa Settings")
+    def setUp(self):
+        create_mpesa_setting_doc()
+        create_mpesa_c2b_payment_register_url_doc()
 
-	@patch('requests.post')
-	def test_validate_success(self, mock_post):
-		mock_post.return_value = Mock(status_code=200)
-		mock_post.return_value.json.return_value = {
-			"ResponseDescription": "Success"
-		}
-		mpesa=frappe.get_doc("Mpesa C2B Payment Register URL","Test Mpesa Settings")
-		mpesa.validate()
+    def tearDown(self):
+        # Delete the Mpesa Settings document
+        mpesa_settings_doc = frappe.get_doc(
+            "Mpesa C2B Payment Register URL", "Test Mpesa Settings"
+        )
+        if mpesa_settings_doc:
+            frappe.delete_doc("Mpesa C2B Payment Register URL", "Test Mpesa Settings")
 
-		self.assertEqual(mpesa.register_status, "Success")
+    @patch("requests.post")
+    def test_validate_success(self, mock_post):
+        mock_post.return_value = Mock(status_code=200)
+        mock_post.return_value.json.return_value = {"ResponseDescription": "Success"}
+        mpesa = frappe.get_doc("Mpesa C2B Payment Register URL", "Test Mpesa Settings")
+        mpesa.validate()
 
-	@patch('requests.post')
-	def test_validate_failure(self, mock_post):
-		mock_post.return_value = Mock(status_code=200)
-		mock_post.return_value.json.return_value = {
-			"ResponseDescription": "Failure"
-		}
-		mpesa=frappe.get_doc("Mpesa C2B Payment Register URL","Test Mpesa Settings")
-		mpesa.validate()
+        self.assertEqual(mpesa.register_status, "Success")
 
-		self.assertEqual(mpesa.register_status, "Failed")
+    @patch("requests.post")
+    def test_validate_failure(self, mock_post):
+        mock_post.return_value = Mock(status_code=200)
+        mock_post.return_value.json.return_value = {"ResponseDescription": "Failure"}
+        mpesa = frappe.get_doc("Mpesa C2B Payment Register URL", "Test Mpesa Settings")
+        mpesa.validate()
 
-	@patch('requests.post')
-	def test_validate_http_error(self, mock_post):
-		mock_post.side_effect = Exception("HTTP Error")
+        self.assertEqual(mpesa.register_status, "Failed")
 
-		mpesa=frappe.get_doc("Mpesa C2B Payment Register URL","Test Mpesa Settings")
-		mpesa.validate()
-  
-		self.assertEqual(mpesa.register_status, "Failed")
-		
+    @patch("requests.post")
+    def test_validate_http_error(self, mock_post):
+        mock_post.side_effect = Exception("HTTP Error")
 
-	@patch('requests.post')
-	def test_validate_connection_error(self, mock_post):
-		mock_post.side_effect = ConnectionError("Connection Error")
+        mpesa = frappe.get_doc("Mpesa C2B Payment Register URL", "Test Mpesa Settings")
+        mpesa.validate()
 
-		mpesa=frappe.get_doc("Mpesa C2B Payment Register URL","Test Mpesa Settings")
-		mpesa.validate()
-  
-		self.assertEqual(mpesa.register_status, "Failed")
+        self.assertEqual(mpesa.register_status, "Failed")
 
-	
+    @patch("requests.post")
+    def test_validate_connection_error(self, mock_post):
+        mock_post.side_effect = ConnectionError("Connection Error")
+
+        mpesa = frappe.get_doc("Mpesa C2B Payment Register URL", "Test Mpesa Settings")
+        mpesa.validate()
+
+        self.assertEqual(mpesa.register_status, "Failed")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_conversion_rate/mpesa_conversion_rate.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_conversion_rate/mpesa_conversion_rate.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class MpesaConversionRate(Document):
-	pass
+    pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_draft_payments/mpesa_draft_payments.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_draft_payments/mpesa_draft_payments.py
@@ -6,27 +6,26 @@ from frappe.model.document import Document
 
 
 class MpesaDraftPayments(Document):
-	
-	def db_insert(self, *args, **kwargs):
-		pass
+    def db_insert(self, *args, **kwargs):
+        pass
 
-	def load_from_db(self):
-		pass
+    def load_from_db(self):
+        pass
 
-	def db_update(self):
-		pass
-	def delete(self):
-		pass
+    def db_update(self):
+        pass
 
-	@staticmethod
-	def get_list(args):
-		pass
+    def delete(self):
+        pass
 
-	@staticmethod
-	def get_count(args):
-		pass
+    @staticmethod
+    def get_list(args):
+        pass
 
-	@staticmethod
-	def get_stats(args):
-		pass
+    @staticmethod
+    def get_count(args):
+        pass
 
+    @staticmethod
+    def get_stats(args):
+        pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.js
@@ -56,8 +56,8 @@ frappe.ui.form.on("Mpesa Express Request", {
 								} else {
 									frappe.msgprint(
 										__(
-											"Missing ResultDesc or ResponseDescription in response.",
-										),
+											"Missing ResultDesc or ResponseDescription in response."
+										)
 									);
 								}
 							} else {
@@ -66,7 +66,7 @@ frappe.ui.form.on("Mpesa Express Request", {
 						},
 					});
 				},
-				__("Mpesa Actions"),
+				__("Mpesa Actions")
 			);
 
 			frm.add_custom_button(
@@ -88,7 +88,7 @@ frappe.ui.form.on("Mpesa Express Request", {
 							const res = r.message;
 							if (res) {
 								frappe.msgprint({
-									message: msg,
+									message: res.CustomerMessage || __("STK Push initiated."),
 									indicator: "green",
 									title: __("STK Push Initiated"),
 								});
@@ -98,7 +98,7 @@ frappe.ui.form.on("Mpesa Express Request", {
 						},
 					});
 				},
-				__("Mpesa Actions"),
+				__("Mpesa Actions")
 			);
 		}
 
@@ -116,7 +116,7 @@ frappe.ui.form.on("Mpesa Express Request", {
 						},
 					});
 				},
-				__("Mpesa Actions"),
+				__("Mpesa Actions")
 			);
 		}
 	},

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
@@ -3,14 +3,16 @@
 
 
 import frappe
-from frappe.model.document import Document
-from frappe_mpsa_payments.utils.doctype_names import MPESA_SETTINGS_DOCTYPE
-from frappe.utils import time
 from frappe.exceptions import DoesNotExistError
+from frappe.model.document import Document
+from frappe.utils import time
+
+from frappe_mpsa_payments.utils.doctype_names import MPESA_SETTINGS_DOCTYPE
+
 from ....utils.utils import (
+    convert_amount_to_kes,
     handle_successful_transaction,
     validate_phone_number,
-    convert_amount_to_kes,
 )
 from ...api.m_pesa_api import (
     check_transaction_status,
@@ -19,7 +21,6 @@ from ...api.m_pesa_api import (
 
 
 class MpesaExpressRequest(Document):
-
     def set_missing_values(self):
         if not self.request_id:
             self.request_id = f"MPESAEXP{frappe.generate_hash(length=32)}"

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/test_mpesa_express_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/test_mpesa_express_request.py
@@ -6,4 +6,4 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestMpesaExpressRequest(FrappeTestCase):
-	pass
+    pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_payment_reconciliation/mpesa_payment_reconciliation.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_payment_reconciliation/mpesa_payment_reconciliation.py
@@ -1,35 +1,33 @@
 # Copyright (c) 2024, Navari Limited and contributors
 # For license information, please see license.txt
 
-import frappe
 from frappe.model.document import Document
 
 
 class MpesaPaymentReconciliation(Document):
-	def save(self):
-		return
-	
-	def db_insert(self, *args, **kwargs):
-		pass
+    def save(self):
+        return
 
-	def load_from_db(self):
-		pass
+    def db_insert(self, *args, **kwargs):
+        pass
 
-	def db_update(self):
-		pass
+    def load_from_db(self):
+        pass
 
-	def delete(self):
-		pass
+    def db_update(self):
+        pass
 
-	@staticmethod
-	def get_list(args):
-		pass
+    def delete(self):
+        pass
 
-	@staticmethod
-	def get_count(args):
-		pass
+    @staticmethod
+    def get_list(args):
+        pass
 
-	@staticmethod
-	def get_stats(args):
-		pass
+    @staticmethod
+    def get_count(args):
+        pass
 
+    @staticmethod
+    def get_stats(args):
+        pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_payment_reconciliation/test_mpesa_payment_reconciliation.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_payment_reconciliation/test_mpesa_payment_reconciliation.py
@@ -6,4 +6,4 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestMpesaPaymentReconciliation(FrappeTestCase):
-	pass
+    pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_payments_invoices/mpesa_payments_invoices.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_payments_invoices/mpesa_payments_invoices.py
@@ -6,28 +6,26 @@ from frappe.model.document import Document
 
 
 class MpesaPaymentsInvoices(Document):
-	
-	def db_insert(self, *args, **kwargs):
-		pass
+    def db_insert(self, *args, **kwargs):
+        pass
 
-	def load_from_db(self):
-		pass
+    def load_from_db(self):
+        pass
 
-	def db_update(self):
-		pass
-	
-	def delete(self):
-		pass
+    def db_update(self):
+        pass
 
-	@staticmethod
-	def get_list(args):
-		pass
+    def delete(self):
+        pass
 
-	@staticmethod
-	def get_count(args):
-		pass
+    @staticmethod
+    def get_list(args):
+        pass
 
-	@staticmethod
-	def get_stats(args):
-		pass
+    @staticmethod
+    def get_count(args):
+        pass
 
+    @staticmethod
+    def get_stats(args):
+        pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_reconciliation_priority/mpesa_reconciliation_priority.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_reconciliation_priority/mpesa_reconciliation_priority.py
@@ -6,4 +6,4 @@ from frappe.model.document import Document
 
 
 class MpesaReconciliationPriority(Document):
-	pass
+    pass

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/payment_gateway/payment_gateway.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/payment_gateway/payment_gateway.js
@@ -2,5 +2,5 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Payment Gateway", {
-  refresh: function (frm) {},
+	refresh: function (frm) {},
 });

--- a/frappe_mpsa_payments/frappe_mpsa_payments/patches/sales_invoice_patch.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/patches/sales_invoice_patch.py
@@ -1,5 +1,5 @@
-import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
 
 def execute():
     custom_fields = {
@@ -14,5 +14,3 @@ def execute():
     }
 
     create_custom_fields(custom_fields)
-    
-    

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/b2c_disbursement_summary/b2c_disbursement_summary.js
@@ -2,105 +2,104 @@
 // For license information, please see license.txt
 
 frappe.query_reports["B2C Disbursement Summary"] = {
-  filters: [
-    {
-      fieldname: "company",
-      label: __("Company"),
-      fieldtype: "Link",
-      options: "Company",
-      reqd: 1,
-      default: frappe.defaults.get_user_default("Company"),
-    },
-    {
-      fieldname: "start_date",
-      label: __("Start Date"),
-      fieldtype: "Date",
-      default: frappe.datetime.add_months(frappe.datetime.get_today(), -5),
-      reqd: 1,
-    },
-    {
-      fieldname: "end_date",
-      label: __("End Date"),
-      fieldtype: "Date",
-      default: frappe.datetime.get_today(),
-      reqd: 1,
-    },
-    {
-      fieldname: "party_type",
-      label: __("Party Type"),
-      fieldtype: "Link",
-      options: "DocType",
-      get_query: function () {
-        return {
-          filters: {
-            name: ["in", ["Supplier", "Employee"]],
-          },
-        };
-      },
-    },
-    {
-      fieldname: "party",
-      label: __("Party"),
-      fieldtype: "Dynamic Link",
-      options: "party_type",
-      get_query: function () {
-        const selected_party_type =
-          frappe.query_report.get_filter_value("party_type");
+	filters: [
+		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			options: "Company",
+			reqd: 1,
+			default: frappe.defaults.get_user_default("Company"),
+		},
+		{
+			fieldname: "start_date",
+			label: __("Start Date"),
+			fieldtype: "Date",
+			default: frappe.datetime.add_months(frappe.datetime.get_today(), -5),
+			reqd: 1,
+		},
+		{
+			fieldname: "end_date",
+			label: __("End Date"),
+			fieldtype: "Date",
+			default: frappe.datetime.get_today(),
+			reqd: 1,
+		},
+		{
+			fieldname: "party_type",
+			label: __("Party Type"),
+			fieldtype: "Link",
+			options: "DocType",
+			get_query: function () {
+				return {
+					filters: {
+						name: ["in", ["Supplier", "Employee"]],
+					},
+				};
+			},
+		},
+		{
+			fieldname: "party",
+			label: __("Party"),
+			fieldtype: "Dynamic Link",
+			options: "party_type",
+			get_query: function () {
+				const selected_party_type = frappe.query_report.get_filter_value("party_type");
 
-        if (selected_party_type == "Employee") {
-          return {
-            filters: {
-              status: "Active",
-            },
-          };
-        }
-      },
-      depends_on: "eval:doc.party_type",
-      mandatory_depends_on: "eval:doc.party_type",
-    },
-    {
-      fieldname: "transaction_to_pay_against",
-      label: __("Transaction to Pay Against"),
-      fieldtype: "Link",
-      options: "DocType",
-      get_query: function () {
-        const doctypes =
-          frappe.query_report.get_filter_value("party_type") === "Employee"
-            ? ["Salary Slip", "Employee Advance", "Expense Claim", "Loan"]
-            : ["Purchase Invoice", "Purchase Order"];
-        return {
-          filters: {
-            name: ["in", doctypes],
-          },
-        };
-      },
-    },
-  ],
-  formatter: function (value, row, column, data, default_formatter) {
-    let formatted_value = default_formatter(value, row, column, data);
+				if (selected_party_type == "Employee") {
+					return {
+						filters: {
+							status: "Active",
+						},
+					};
+				}
+			},
+			depends_on: "eval:doc.party_type",
+			mandatory_depends_on: "eval:doc.party_type",
+		},
+		{
+			fieldname: "transaction_to_pay_against",
+			label: __("Transaction to Pay Against"),
+			fieldtype: "Link",
+			options: "DocType",
+			get_query: function () {
+				const doctypes =
+					frappe.query_report.get_filter_value("party_type") === "Employee"
+						? ["Salary Slip", "Employee Advance", "Expense Claim", "Loan"]
+						: ["Purchase Invoice", "Purchase Order"];
+				return {
+					filters: {
+						name: ["in", doctypes],
+					},
+				};
+			},
+		},
+	],
+	formatter: function (value, row, column, data, default_formatter) {
+		let formatted_value = default_formatter(value, row, column, data);
 
-    if (data && data.is_subtotal) {
-      formatted_value = `<span style="font-weight: bold;">${formatted_value}</span>`;
-    }
+		if (data && data.is_subtotal) {
+			formatted_value = `<span style="font-weight: bold;">${formatted_value}</span>`;
+		}
 
-    const blankFields = ["total_amount"];
+		const blankFields = ["total_amount"];
 
-    const isBlankableColumn =
-      blankFields.includes(column.fieldname) || /\d+$/.test(column.fieldname);
+		const isBlankableColumn =
+			blankFields.includes(column.fieldname) || /\d+$/.test(column.fieldname);
 
-    const shouldBlank =
-      data &&
-      (value === null ||
-        value === undefined ||
-        value === "" ||
-        value === 0 ||
-        value === "0%" ||
-        formatted_value === "Sh 0.00");
+		const shouldBlank =
+			data &&
+			(value === null ||
+				value === undefined ||
+				value === "" ||
+				value === 0 ||
+				value === "0%" ||
+				formatted_value === "Sh 0.00");
 
-    if (isBlankableColumn && shouldBlank) {
-      return "";
-    }
+		if (isBlankableColumn && shouldBlank) {
+			return "";
+		}
 
-    return formatted_value;
-  },
+		return formatted_value;
+	},
 };

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/c2b_payment_summary_group_by_customer/c2b_payment_summary_group_by_customer.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/c2b_payment_summary_group_by_customer/c2b_payment_summary_group_by_customer.js
@@ -1,82 +1,82 @@
 // Copyright (c) 2025, Navari Limited and contributors
 // For license information, please see license.txt
 
-frappe.query_reports['C2B Payment Summary Group by Customer'] = {
-  filters: [
-    {
-      fieldname: 'start_date',
-      label: __('Start Date'),
-      fieldtype: 'Date',
-      default: frappe.datetime.add_months(frappe.datetime.get_today(), -5),
-      reqd: 1,
-    },
-    {
-      fieldname: 'end_date',
-      label: __('End Date'),
-      fieldtype: 'Date',
-      default: frappe.datetime.get_today(),
-      reqd: 1,
-    },
-    {
-      fieldname: 'company',
-      label: __('Company'),
-      fieldtype: 'Link',
-      options: 'Company',
-      reqd: 1,
-      default: frappe.defaults.get_user_default('Company'),
-    },
-    {
-      fieldname: 'status',
-      label: __('Status'),
-      fieldtype: 'Select',
-      options: '\nDraft\nSubmitted\nCancelled',
-    },
-    {
-      fieldname: 'group_by_customer',
-      label: __('Group by Customer'),
-      fieldtype: 'Check',
-      default: 0,
-    },
-  ],
-  formatter: function (value, row, column, data, default_formatter) {
-    let formatted_value = default_formatter(value, row, column, data);
+frappe.query_reports["C2B Payment Summary Group by Customer"] = {
+	filters: [
+		{
+			fieldname: "start_date",
+			label: __("Start Date"),
+			fieldtype: "Date",
+			default: frappe.datetime.add_months(frappe.datetime.get_today(), -5),
+			reqd: 1,
+		},
+		{
+			fieldname: "end_date",
+			label: __("End Date"),
+			fieldtype: "Date",
+			default: frappe.datetime.get_today(),
+			reqd: 1,
+		},
+		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			options: "Company",
+			reqd: 1,
+			default: frappe.defaults.get_user_default("Company"),
+		},
+		{
+			fieldname: "status",
+			label: __("Status"),
+			fieldtype: "Select",
+			options: "\nDraft\nSubmitted\nCancelled",
+		},
+		{
+			fieldname: "group_by_customer",
+			label: __("Group by Customer"),
+			fieldtype: "Check",
+			default: 0,
+		},
+	],
+	formatter: function (value, row, column, data, default_formatter) {
+		let formatted_value = default_formatter(value, row, column, data);
 
-    if (data && data.is_subtotal) {
-      formatted_value = `<span style="font-weight: bold;">${formatted_value}</span>`;
-    }
+		if (data && data.is_subtotal) {
+			formatted_value = `<span style="font-weight: bold;">${formatted_value}</span>`;
+		}
 
-    const blankFields = ['amount', 'transamount'];
+		const blankFields = ["amount", "transamount"];
 
-    const isBlankableColumn =
-      blankFields.includes(column.fieldname) || /\d+$/.test(column.fieldname);
+		const isBlankableColumn =
+			blankFields.includes(column.fieldname) || /\d+$/.test(column.fieldname);
 
-    const shouldBlank =
-      data &&
-      (value === null ||
-        value === undefined ||
-        value === '' ||
-        value === 0 ||
-        value === '0%' ||
-        formatted_value === 'Sh 0.00');
+		const shouldBlank =
+			data &&
+			(value === null ||
+				value === undefined ||
+				value === "" ||
+				value === 0 ||
+				value === "0%" ||
+				formatted_value === "Sh 0.00");
 
-    if (isBlankableColumn && shouldBlank) {
-      return '';
-    }
+		if (isBlankableColumn && shouldBlank) {
+			return "";
+		}
 
-    if (column.fieldname === 'status') {
-      const colorMap = {
-        Submitted: 'green',
-        Cancelled: 'red',
-        Draft: 'orange',
-      };
+		if (column.fieldname === "status") {
+			const colorMap = {
+				Submitted: "green",
+				Cancelled: "red",
+				Draft: "orange",
+			};
 
-      const color = colorMap[value];
+			const color = colorMap[value];
 
-      if (color) {
-        formatted_value = `<span style="color: ${color}; font-weight: bold;">${formatted_value}</span>`;
-      }
-    }
+			if (color) {
+				formatted_value = `<span style="color: ${color}; font-weight: bold;">${formatted_value}</span>`;
+			}
+		}
 
-    return formatted_value;
-  },
+		return formatted_value;
+	},
 };

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/c2b_payment_summary_group_by_customer/c2b_payment_summary_group_by_customer.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/c2b_payment_summary_group_by_customer/c2b_payment_summary_group_by_customer.py
@@ -3,8 +3,6 @@
 
 import frappe
 from frappe.query_builder import DocType
-from pypika.terms import Criterion
-from pypika.functions import Sum, Count, Max
 
 
 def execute(filters=None):
@@ -166,7 +164,9 @@ def get_data(filters):
             data.extend(customer_payments)
             data.append(
                 create_subtotal_row(
-                    current_customer, customer_payments[0]["customer_name"], customer_total_amount
+                    current_customer,
+                    customer_payments[0]["customer_name"],
+                    customer_total_amount,
                 )
             )
             data.append({})  # Add an empty row for separation
@@ -185,7 +185,9 @@ def get_data(filters):
         data.extend(customer_payments)
         data.append(
             create_subtotal_row(
-                current_customer, customer_payments[0]["customer_name"], customer_total_amount
+                current_customer,
+                customer_payments[0]["customer_name"],
+                customer_total_amount,
             )
         )
         data.append({})

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/c2b_reconciliation_report/c2b_reconciliation_report.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/c2b_reconciliation_report/c2b_reconciliation_report.js
@@ -1,57 +1,57 @@
 // Copyright (c) 2025, Navari Limited and contributors
 // For license information, please see license.txt
 
-frappe.query_reports['C2B Reconciliation Report'] = {
-  filters: [
-    {
-      fieldname: 'start_date',
-      fieldtype: 'Date',
-      label: __('Start Date'),
-      default: frappe.datetime.add_days(frappe.datetime.get_today(), -30),
-      reqd: 1,
-    },
-    {
-      fieldname: 'end_date',
-      fieldtype: 'Date',
-      label: __('End Date'),
-      default: frappe.datetime.get_today(),
-      reqd: 1,
-    },
-    {
-      fieldname: 'company',
-      fieldtype: 'Link',
-      label: __('Company'),
-      options: 'Company',
-      default: frappe.defaults.get_user_default('Company'),
-      reqd: 1,
-    },
-    {
-      fieldname: 'status',
-      fieldtype: 'Select',
-      label: __('Status'),
-      options: ['', 'Draft', 'Submitted', 'Cancelled'],
-      default: 'Submitted',
-      reqd: 1,
-    },
-    {
-      fieldname: 'unlinked_mpesa_payments',
-      fieldtype: 'Check',
-      label: __('Mpesa Payments not linked to a Payment Entry'),
-    },
-  ],
-  formatter: function (value, row, column, data, default_formatter) {
-    value = default_formatter(value, row, column, data);
-    if (column.fieldname === 'status') {
-      const colorMap = {
-        Submitted: 'green',
-        Cancelled: 'red',
-        Draft: 'orange',
-      };
-      const color = colorMap[value];
-      if (color) {
-        value = `<span style="color: ${color}; font-weight: bold;">${value}</span>`;
-      }
-    }
-    return value;
-  },
+frappe.query_reports["C2B Reconciliation Report"] = {
+	filters: [
+		{
+			fieldname: "start_date",
+			fieldtype: "Date",
+			label: __("Start Date"),
+			default: frappe.datetime.add_days(frappe.datetime.get_today(), -30),
+			reqd: 1,
+		},
+		{
+			fieldname: "end_date",
+			fieldtype: "Date",
+			label: __("End Date"),
+			default: frappe.datetime.get_today(),
+			reqd: 1,
+		},
+		{
+			fieldname: "company",
+			fieldtype: "Link",
+			label: __("Company"),
+			options: "Company",
+			default: frappe.defaults.get_user_default("Company"),
+			reqd: 1,
+		},
+		{
+			fieldname: "status",
+			fieldtype: "Select",
+			label: __("Status"),
+			options: ["", "Draft", "Submitted", "Cancelled"],
+			default: "Submitted",
+			reqd: 1,
+		},
+		{
+			fieldname: "unlinked_mpesa_payments",
+			fieldtype: "Check",
+			label: __("Mpesa Payments not linked to a Payment Entry"),
+		},
+	],
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+		if (column.fieldname === "status") {
+			const colorMap = {
+				Submitted: "green",
+				Cancelled: "red",
+				Draft: "orange",
+			};
+			const color = colorMap[value];
+			if (color) {
+				value = `<span style="color: ${color}; font-weight: bold;">${value}</span>`;
+			}
+		}
+		return value;
+	},
 };

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/c2b_reconciliation_report/c2b_reconciliation_report.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/c2b_reconciliation_report/c2b_reconciliation_report.py
@@ -4,7 +4,6 @@
 import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Coalesce
-from pypika.terms import Criterion
 
 
 def execute(filters=None):

--- a/frappe_mpsa_payments/frappe_mpsa_payments/report/stk_push_request_status/stk_push_request_status.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/report/stk_push_request_status/stk_push_request_status.js
@@ -1,68 +1,68 @@
 // Copyright (c) 2025, Navari Limited and contributors
 // For license information, please see license.txt
 
-frappe.query_reports['STK Push Request Status'] = {
-  filters: [
-    {
-      fieldname: 'status',
-      label: __('Status'),
-      fieldtype: 'Select',
-      options: '\nPending\nSuccess\nFailed',
-      default: 'Pending',
-    },
-    {
-      fieldname: 'start_date',
-      label: __('Start Date'),
-      fieldtype: 'Date',
-      default: '2025-01-01',
-    },
-    {
-      fieldname: 'end_date',
-      label: __('End Date'),
-      fieldtype: 'Date',
-      default: frappe.datetime.get_today(),
-    },
-    {
-      fieldname: 'company',
-      label: __('Company'),
-      fieldtype: 'Link',
-      options: 'Company',
-      default: frappe.defaults.get_user_default('Company'),
-      reqd: 1,
-    },
-    {
-      fieldname: 'voucher_type',
-      label: __('Voucher Type'),
-      fieldtype: 'Select',
-      options: 'Purchase Invoice\nSales Invoice\nPOS Invoice',
-      default: 'Purchase Invoice',
-    },
-    {
-      fieldname: 'voucher_no',
-      label: __('Voucher No'),
-      fieldtype: 'Link',
-    },
-    {
-      fieldname: 'phone_number',
-      label: __('Phone Number'),
-      fieldtype: 'Data',
-      description: __('Filter by phone number (optional)'),
-      default: '',
-    },
-  ],
-  formatter: function (value, row, column, data, default_formatter) {
-    value = default_formatter(value, row, column, data);
-    if (column.fieldname === 'status') {
-      const colorMap = {
-        Success: 'green',
-        Failed: 'red',
-        Pending: 'orange',
-      };
-      const color = colorMap[value];
-      if (color) {
-        value = `<span style="color: ${color}; font-weight: bold;">${value}</span>`;
-      }
-    }
-    return value;
-  },
+frappe.query_reports["STK Push Request Status"] = {
+	filters: [
+		{
+			fieldname: "status",
+			label: __("Status"),
+			fieldtype: "Select",
+			options: "\nPending\nSuccess\nFailed",
+			default: "Pending",
+		},
+		{
+			fieldname: "start_date",
+			label: __("Start Date"),
+			fieldtype: "Date",
+			default: "2025-01-01",
+		},
+		{
+			fieldname: "end_date",
+			label: __("End Date"),
+			fieldtype: "Date",
+			default: frappe.datetime.get_today(),
+		},
+		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			options: "Company",
+			default: frappe.defaults.get_user_default("Company"),
+			reqd: 1,
+		},
+		{
+			fieldname: "voucher_type",
+			label: __("Voucher Type"),
+			fieldtype: "Select",
+			options: "Purchase Invoice\nSales Invoice\nPOS Invoice",
+			default: "Purchase Invoice",
+		},
+		{
+			fieldname: "voucher_no",
+			label: __("Voucher No"),
+			fieldtype: "Link",
+		},
+		{
+			fieldname: "phone_number",
+			label: __("Phone Number"),
+			fieldtype: "Data",
+			description: __("Filter by phone number (optional)"),
+			default: "",
+		},
+	],
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+		if (column.fieldname === "status") {
+			const colorMap = {
+				Success: "green",
+				Failed: "red",
+				Pending: "orange",
+			};
+			const color = colorMap[value];
+			if (color) {
+				value = `<span style="color: ${color}; font-weight: bold;">${value}</span>`;
+			}
+		}
+		return value;
+	},
 };

--- a/frappe_mpsa_payments/public/js/payment_request.js
+++ b/frappe_mpsa_payments/public/js/payment_request.js
@@ -1,77 +1,69 @@
 frappe.ui.form.on("Payment Request", {
-  refresh: function (frm) {
-    sync_payment_fields(frm);
-  },
+	refresh: function (frm) {
+		sync_payment_fields(frm);
+	},
 
-  mode_of_payment: function (frm) {
-    if (frm.doc.mode_of_payment && frm.doc.company) {
-      frappe.call({
-        method:
-          "frappe_mpsa_payments.frappe_mpsa_payments.api.sales_invoice.get_payment_gateway_from_mop",
-        args: {
-          mode_of_payment: frm.doc.mode_of_payment,
-          company: frm.doc.company,
-        },
-        callback: function (r) {
-          if (!r.exc && r.message) {
-            frm.set_value("payment_gateway", r.message);
-          }
-        },
-      });
-    }
-  },
+	mode_of_payment: function (frm) {
+		if (frm.doc.mode_of_payment && frm.doc.company) {
+			frappe.call({
+				method: "frappe_mpsa_payments.frappe_mpsa_payments.api.sales_invoice.get_payment_gateway_from_mop",
+				args: {
+					mode_of_payment: frm.doc.mode_of_payment,
+					company: frm.doc.company,
+				},
+				callback: function (r) {
+					if (!r.exc && r.message) {
+						frm.set_value("payment_gateway", r.message);
+					}
+				},
+			});
+		}
+	},
 
-  payment_gateway: function (frm) {
-    if (frm.doc.payment_gateway && frm.doc.company) {
-      frappe.call({
-        method:
-          "frappe_mpsa_payments.frappe_mpsa_payments.api.sales_invoice.get_mop_from_payment_gateway",
-        args: {
-          payment_gateway: frm.doc.payment_gateway,
-          company: frm.doc.company,
-        },
-        callback: function (r) {
-          if (!r.exc && r.message) {
-            frm.set_value("mode_of_payment", r.message);
-          }
-        },
-      });
-    }
-  },
+	payment_gateway: function (frm) {
+		if (frm.doc.payment_gateway && frm.doc.company) {
+			frappe.call({
+				method: "frappe_mpsa_payments.frappe_mpsa_payments.api.sales_invoice.get_mop_from_payment_gateway",
+				args: {
+					payment_gateway: frm.doc.payment_gateway,
+					company: frm.doc.company,
+				},
+				callback: function (r) {
+					if (!r.exc && r.message) {
+						frm.set_value("mode_of_payment", r.message);
+					}
+				},
+			});
+		}
+	},
 });
 
 function sync_payment_fields(frm) {
-  if (frm.doc.mode_of_payment && !frm.doc.payment_gateway && frm.doc.company) {
-    frappe.call({
-      method:
-        "frappe_mpsa_payments.frappe_mpsa_payments.api.sales_invoice.get_payment_gateway_from_mop",
-      args: {
-        mode_of_payment: frm.doc.mode_of_payment,
-        company: frm.doc.company,
-      },
-      callback: function (r) {
-        if (!r.exc && r.message) {
-          frm.set_value("payment_gateway", r.message);
-        }
-      },
-    });
-  } else if (
-    frm.doc.payment_gateway &&
-    !frm.doc.mode_of_payment &&
-    frm.doc.company
-  ) {
-    frappe.call({
-      method:
-        "frappe_mpsa_payments.frappe_mpsa_payments.api.sales_invoice.get_mop_from_payment_gateway",
-      args: {
-        payment_gateway: frm.doc.payment_gateway,
-        company: frm.doc.company,
-      },
-      callback: function (r) {
-        if (!r.exc && r.message) {
-          frm.set_value("mode_of_payment", r.message);
-        }
-      },
-    });
-  }
+	if (frm.doc.mode_of_payment && !frm.doc.payment_gateway && frm.doc.company) {
+		frappe.call({
+			method: "frappe_mpsa_payments.frappe_mpsa_payments.api.sales_invoice.get_payment_gateway_from_mop",
+			args: {
+				mode_of_payment: frm.doc.mode_of_payment,
+				company: frm.doc.company,
+			},
+			callback: function (r) {
+				if (!r.exc && r.message) {
+					frm.set_value("payment_gateway", r.message);
+				}
+			},
+		});
+	} else if (frm.doc.payment_gateway && !frm.doc.mode_of_payment && frm.doc.company) {
+		frappe.call({
+			method: "frappe_mpsa_payments.frappe_mpsa_payments.api.sales_invoice.get_mop_from_payment_gateway",
+			args: {
+				payment_gateway: frm.doc.payment_gateway,
+				company: frm.doc.company,
+			},
+			callback: function (r) {
+				if (!r.exc && r.message) {
+					frm.set_value("mode_of_payment", r.message);
+				}
+			},
+		});
+	}
 }

--- a/frappe_mpsa_payments/utils/encoding_initiator_password.py
+++ b/frappe_mpsa_payments/utils/encoding_initiator_password.py
@@ -1,10 +1,9 @@
-import frappe
 import base64
 import os
+
+import frappe
 from cryptography import x509
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
-from datetime import datetime
 
 
 def load_certificate_path(cert_url: str, sandbox: bool) -> str:
@@ -38,7 +37,6 @@ def generate_security_credential(
     following M-Pesa's security credential generation requirements.
     """
     try:
-
         full_path = load_certificate_path(certificate_path, sandbox)
 
         with open(full_path, "rb") as cert_file:

--- a/frappe_mpsa_payments/utils/utils.py
+++ b/frappe_mpsa_payments/utils/utils.py
@@ -170,7 +170,10 @@ def log_and_throw_error(err_msg, context=None):
 def handle_successful_transaction(request_doc, settings):
     """Handle actions for a successful transaction"""
 
-    if request_doc.reference_doctype == "Payment Entry" and not request_doc.transaction_id:
+    if (
+        request_doc.reference_doctype == "Payment Entry"
+        and not request_doc.transaction_id
+    ):
         return
 
     if request_doc.get("reference_doctype") and request_doc.get("reference_name"):

--- a/frappe_mpsa_payments/www/mpesa/stkpush.py
+++ b/frappe_mpsa_payments/www/mpesa/stkpush.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe import _
 from frappe.utils import now
-import json
 
 
 def get_context(context):
@@ -99,7 +98,7 @@ def check_payment_status(name):
     redirect_to = doc.redirect_to
     if doc.reference_doctype == "Payment Entry" and not doc.is_reconciled:
         redirect_to = None
-    
+
     return {
         "status": doc.status,
         "docstatus": doc.docstatus,


### PR DESCRIPTION
Stacked on #118 — review that one first. Together they take the Linters job fully green.

`b2c_payment_disbursement.js` opened with a bare top-level `return` guarding the erpnext check. Frappe runs doctype scripts through `new Function(...)`, so that works at runtime — the file is not broken in production. But it is linted as a module, where a top-level return is a syntax error, and **the parse failure was hiding every other problem in the file**.

The handlers now live in a const, registered behind the guard. That keeps the diff at ~10 lines rather than reindenting 680.

With the file actually parsing, three more errors surfaced:

| Error | Assessment |
| --- | --- |
| `erpnext` is not defined (×2) | A real runtime global, just missing from `.eslintrc`. Usage is already guarded by `HAS_ERPNEXT`. |
| `btn_text` is not defined (×2) | Assigned with no declaration, leaking an implicit global in non-strict mode. Now `const`. |
| Duplicate key `outstanding_amt_greater_than` | Listed twice with identical values, so removing one changes nothing. |

Verified: eslint reports zero errors across all in-scope files, prettier clean, and the file still parses under `new Function(...)` the way Frappe executes it.