### PR TITLE
Clear the remaining eslint errors in B2C Payment Disbursement

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
 	"root": true,
 	"globals": {
 		"frappe": true,
+		"erpnext": true,
 		"Vue": true,
 		"SetVueGlobals": true,
 		"__": true,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
@@ -3,11 +3,10 @@
 
 const HAS_ERPNEXT = frappe.boot?.app_data?.some((app) => app.app_name === "erpnext");
 
-if (!HAS_ERPNEXT) {
-	return;
-}
-
-frappe.ui.form.on("B2C Payment Disbursement", {
+// Frappe runs doctype scripts through `new Function(...)`, so a bare top-level
+// return works at runtime - but the file is linted as a module, where it is a
+// syntax error. Hold the handlers and register them behind the guard instead.
+const B2C_HANDLERS = {
 	onload: function (frm) {
 		frm.ignore_doctypes_on_cancel_all = [
 			"Employee Advance",
@@ -516,7 +515,7 @@ frappe.ui.form.on("B2C Payment Disbursement", {
 			},
 		]);
 
-		btn_text = "Get Outstanding References";
+		const btn_text = "Get Outstanding References";
 
 		frappe.prompt(
 			fields,
@@ -595,7 +594,6 @@ frappe.ui.form.on("B2C Payment Disbursement", {
 			to_posting_date: filters.to_posting_date,
 			from_due_date: filters.from_due_date,
 			to_due_date: filters.to_due_date,
-			outstanding_amt_greater_than: filters.outstanding_amt_greater_than,
 			outstanding_amt_greater_than: filters.outstanding_amt_greater_than,
 		};
 
@@ -689,7 +687,11 @@ frappe.ui.form.on("B2C Payment Disbursement", {
 			},
 		});
 	},
-});
+};
+
+if (HAS_ERPNEXT) {
+	frappe.ui.form.on("B2C Payment Disbursement", B2C_HANDLERS);
+}
 
 function generateUUIDv4() {
 	// Generates a uuid4 string conforming to RFC standards


### PR DESCRIPTION
Depends on the pre-commit PR — review that first.

`b2c_payment_disbursement.js` opens with a bare top-level `return` guarding the erpnext check. Frappe runs doctype scripts through `new Function(...)`, so this works at runtime and the form is **not** broken in production. But the file is linted as a module, where a top-level return is a syntax error — and that parse failure was hiding every other problem in the file.

The handlers now live in a const, registered behind the guard, keeping the diff at ~10 lines rather than reindenting 680.

With the file parsing, three more errors surfaced:

| Error | Assessment |
| --- | --- |
| `erpnext` is not defined (×2) | A real runtime global, missing from `.eslintrc`. Usage is already guarded by `HAS_ERPNEXT`. |
| `btn_text` is not defined (×2) | Assigned with no declaration, leaking an implicit global. Now `const`. |
| Duplicate key `outstanding_amt_greater_than` | Listed twice with identical values, so removing one changes nothing. |

I considered simply allowing `globalReturn` in eslint instead, but rejected it: the bundles under `public/js` genuinely are modules, so that would mask real errors there.

eslint now reports zero errors across all in-scope files.