### PR TITLE
Cut pull transaction error log noise, add a Pull button to the C2B register

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -23,6 +23,7 @@ from ...utils.utils import (
     update_mpesa_request_status,
 )
 from .mpesa_response_handler import (
+    BULK_PULL_BATCH_FLAG,
     BULK_PULL_FLAG,
     BULK_PULL_RESULTS_FLAG,
     balance_query_on_success,
@@ -1250,6 +1251,7 @@ def execute_bulk_pull_transactions(
     toasts can be suppressed via BULK_PULL_FLAG and replaced by a single message.
     """
     frappe.flags[BULK_PULL_FLAG] = True
+    frappe.flags[BULK_PULL_BATCH_FLAG] = True
     frappe.flags[BULK_PULL_RESULTS_FLAG] = []
 
     skipped_settings = []
@@ -1274,6 +1276,7 @@ def execute_bulk_pull_transactions(
         results = frappe.flags.get(BULK_PULL_RESULTS_FLAG) or []
     finally:
         frappe.flags[BULK_PULL_FLAG] = False
+        frappe.flags[BULK_PULL_BATCH_FLAG] = False
 
     imported = sum(r.get("created") or 0 for r in results)
     no_data = [r for r in results if r.get("response_code") == "1001"]

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -1049,8 +1049,8 @@ PULL_MAX_PAGES = 50
 def execute_pull_transactions(mpesa_settings: str, payload: dict) -> None:
     """Pull every page Safaricom has for the window, not just the first one.
 
-    Safaricom paginates: a 48h window on a busy shortcode came back as
-    TotalRecords 318 across TotalPages 4. We used to send OffSetValue once and
+    Safaricom paginates: a 48h window on a busy shortcode can come back as
+    several hundred records across several pages. We used to send OffSetValue once and
     import whatever single page came back, silently dropping the rest unless
     someone manually re-ran with offset 1, 2, 3. Now we walk the pages.
 

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -141,6 +141,11 @@ PULL_NO_RECORDS_HINT = (
 BULK_PULL_FLAG = "mpesa_bulk_pull"
 BULK_PULL_RESULTS_FLAG = "mpesa_bulk_pull_results"
 
+# Set only when sweeping many shortcodes at once (hourly job, bulk pull action).
+# In that mode a per-shortcode 1001 is noise: most branches simply took no
+# payments in the window, and the run writes one summary listing all of them.
+BULK_PULL_BATCH_FLAG = "mpesa_bulk_pull_batch"
+
 
 def publish_pull_result(message: dict) -> None:
     """Emit one toast per pull - unless a bulk run is collecting them.
@@ -239,10 +244,13 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
             log_message.append("")
             log_message.append(PULL_NO_RECORDS_HINT)
 
-        frappe.log_error(
-            title=f"Mpesa Pull Transaction: {response_code} from Safaricom",
-            message="\n".join(log_message),
-        )
+        # In a batch sweep the summary covers this; logging each shortcode
+        # separately produced ~800 near-identical entries a day.
+        if not frappe.flags.get(BULK_PULL_BATCH_FLAG):
+            frappe.log_error(
+                title=f"Mpesa Pull Transaction: {response_code} from Safaricom",
+                message="\n".join(log_message),
+            )
 
         record_pull_outcome(
             settings.name,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -273,25 +273,21 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
 
     created, skipped, failed = 0, 0, 0
     created_records = []
+    duplicate_transids = []
+    malformed = []
 
     for txn in transactions:
         try:
             transid = txn.get("transactionId", "")
             if not transid:
-                frappe.log_error(
-                    title="Mpesa Pull Transaction: Missing TransactionID",
-                    message=f"Transaction payload missing transactionId: {txn}",
-                )
+                malformed.append(str(txn))
                 skipped += 1
                 continue
 
             if frappe.db.exists(
                 MPESA_C2B_PAYMENT_REGISTER_DOCTYPE, {"transid": transid}
             ):
-                frappe.log_error(
-                    title="Mpesa Pull Transaction: Duplicate Skipped",
-                    message=f"transid={transid} already exists in {MPESA_C2B_PAYMENT_REGISTER_DOCTYPE}",
-                )
+                duplicate_transids.append(transid)
                 skipped += 1
                 continue
 
@@ -325,10 +321,31 @@ def pull_transaction_on_success(response: dict, document_name: str, **kwargs) ->
 
     frappe.db.commit()
 
-    if created_records:
+    # One log per pull, not one per transaction. A busy shortcode re-pulls
+    # dozens of transactions the webhook already delivered, and logging each
+    # duplicate separately buried everything else.
+    if created_records or duplicate_transids or malformed:
+        summary = [
+            f"Settings: {settings.name}",
+            f"ShortCode: {shortcode!r}",
+            f"Window: {kwargs.get('payload', {})}",
+            f"Returned by Safaricom: {len(transactions)}",
+            f"Created: {created}   Skipped: {skipped}   Failed: {failed}",
+        ]
+        if created_records:
+            summary += ["", "Created:", frappe.as_json(created_records)]
+        if duplicate_transids:
+            summary += [
+                "",
+                f"Already present, skipped ({len(duplicate_transids)}):",
+                ", ".join(duplicate_transids),
+            ]
+        if malformed:
+            summary += ["", "Missing transactionId:"] + malformed
+
         frappe.log_error(
-            title="Mpesa Pull Transaction: Records Created",
-            message=frappe.as_json(created_records),
+            title=f"Mpesa Pull Transaction: {settings.name} - {created} created, {skipped} skipped",
+            message="\n".join(summary),
         )
 
     record_pull_outcome(

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -150,7 +150,7 @@ BULK_PULL_BATCH_FLAG = "mpesa_bulk_pull_batch"
 def publish_pull_result(message: dict) -> None:
     """Emit one toast per pull - unless a bulk run is collecting them.
 
-    A bulk pull over 69 shortcodes would otherwise fire 69 separate popups. The
+    A bulk pull over many shortcodes would otherwise fire one popup each. The
     bulk worker sets the flag, runs everything in its own job, and publishes a
     single summary at the end.
     """

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/test_pull_transactions.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/test_pull_transactions.py
@@ -12,7 +12,9 @@ from unittest.mock import patch
 import frappe
 
 from frappe_mpsa_payments.frappe_mpsa_payments.api import m_pesa_api as api
-from frappe_mpsa_payments.frappe_mpsa_payments.api import mpesa_response_handler as handler
+from frappe_mpsa_payments.frappe_mpsa_payments.api import (
+    mpesa_response_handler as handler,
+)
 
 SETTINGS_NAME = "_Pull Test"
 
@@ -33,12 +35,17 @@ class TestPullTransactionResponses(unittest.TestCase):
 
         frappe.flags[handler.BULK_PULL_BATCH_FLAG] = batch
         try:
-            with patch.object(handler.frappe, "get_doc", return_value=_StubSettings()), patch.object(
-                handler, "record_pull_outcome"
-            ), patch.object(
-                handler, "publish_pull_result", side_effect=published.append
-            ), patch.object(
-                handler.frappe, "log_error", side_effect=lambda *a, **k: logged.append(k.get("title"))
+            with (
+                patch.object(handler.frappe, "get_doc", return_value=_StubSettings()),
+                patch.object(handler, "record_pull_outcome"),
+                patch.object(
+                    handler, "publish_pull_result", side_effect=published.append
+                ),
+                patch.object(
+                    handler.frappe,
+                    "log_error",
+                    side_effect=lambda *a, **k: logged.append(k.get("title")),
+                ),
             ):
                 handler.pull_transaction_on_success(
                     response=response,
@@ -98,18 +105,24 @@ class TestPullPagination(unittest.TestCase):
         def fake_request(**kwargs):
             requested.append(int(kwargs["payload"]["OffSetValue"]))
             kwargs["success_callback"](
-                response={"ResponseCode": "1000", "Response": [], "TotalPages": total_pages},
+                response={
+                    "ResponseCode": "1000",
+                    "Response": [],
+                    "TotalPages": total_pages,
+                },
                 document_name=SETTINGS_NAME,
                 settings_name=SETTINGS_NAME,
                 integration_request=None,
             )
             return {"ResponseCode": "1000", "TotalPages": total_pages}
 
-        with patch.object(api, "process_request", side_effect=fake_request), patch.object(
-            api.frappe, "publish_realtime"
-        ), patch.object(handler.frappe, "get_doc", return_value=_StubSettings()), patch.object(
-            handler, "record_pull_outcome"
-        ), patch.object(handler.frappe, "log_error"):
+        with (
+            patch.object(api, "process_request", side_effect=fake_request),
+            patch.object(api.frappe, "publish_realtime"),
+            patch.object(handler.frappe, "get_doc", return_value=_StubSettings()),
+            patch.object(handler, "record_pull_outcome"),
+            patch.object(handler.frappe, "log_error"),
+        ):
             api.execute_pull_transactions(
                 mpesa_settings=SETTINGS_NAME,
                 payload={"ShortCode": "898048", "OffSetValue": "0"},

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/test_pull_transactions.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/test_pull_transactions.py
@@ -1,0 +1,126 @@
+"""Pull transaction regression tests.
+
+Deliberately self-contained: these mock at the frappe boundary rather than
+building Mpesa Settings / Company / POS Profile fixtures, so they run on any
+site. test_mpesa_settings.py needs a specific company fixture and cannot run
+on most benches, which is how the 1001-reported-as-success bug survived.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from frappe_mpsa_payments.frappe_mpsa_payments.api import m_pesa_api as api
+from frappe_mpsa_payments.frappe_mpsa_payments.api import mpesa_response_handler as handler
+
+SETTINGS_NAME = "_Pull Test"
+
+
+class _StubSettings:
+    name = SETTINGS_NAME
+    sandbox = 0
+    business_shortcode = "898048"
+    till_number = None
+
+
+class TestPullTransactionResponses(unittest.TestCase):
+    """Safaricom signals failure in the body while returning HTTP 200."""
+
+    def _run(self, response, batch=False):
+        published = []
+        logged = []
+
+        frappe.flags[handler.BULK_PULL_BATCH_FLAG] = batch
+        try:
+            with patch.object(handler.frappe, "get_doc", return_value=_StubSettings()), patch.object(
+                handler, "record_pull_outcome"
+            ), patch.object(
+                handler, "publish_pull_result", side_effect=published.append
+            ), patch.object(
+                handler.frappe, "log_error", side_effect=lambda *a, **k: logged.append(k.get("title"))
+            ):
+                handler.pull_transaction_on_success(
+                    response=response,
+                    document_name=SETTINGS_NAME,
+                    settings_name=SETTINGS_NAME,
+                    integration_request=None,
+                    payload={"ShortCode": "898048"},
+                )
+        finally:
+            frappe.flags[handler.BULK_PULL_BATCH_FLAG] = False
+
+        return published[0] if published else {}, logged
+
+    def test_1001_is_not_reported_as_a_successful_import(self):
+        msg, logged = self._run(
+            {
+                "ResponseCode": "1001",
+                "ResponseMessage": "No records found or Organization Name not available",
+            }
+        )
+        self.assertEqual(msg.get("status"), "warning")
+        self.assertEqual(msg.get("response_code"), "1001")
+        self.assertEqual(msg.get("count"), 0)
+        self.assertIn("1001", msg.get("message", ""))
+        self.assertNotIn("record(s) imported", msg.get("message", ""))
+        self.assertEqual(len(logged), 1)
+
+    def test_other_error_codes_report_as_error(self):
+        msg, _ = self._run(
+            {"ResponseCode": "500.003.02", "ResponseMessage": "Internal server error"}
+        )
+        self.assertEqual(msg.get("status"), "error")
+        self.assertEqual(msg.get("count"), 0)
+
+    def test_1000_with_empty_response_is_a_quiet_window(self):
+        msg, _ = self._run(
+            {"ResponseCode": "1000", "ResponseMessage": "Success", "Response": []}
+        )
+        self.assertIn("0 record(s) imported", msg.get("message", ""))
+        self.assertEqual(msg.get("count"), 0)
+
+    def test_batch_mode_suppresses_the_per_shortcode_log(self):
+        """~69 shortcodes x 12 runs a day made these logs unreadable."""
+        msg, logged = self._run(
+            {"ResponseCode": "1001", "ResponseMessage": "No records found"}, batch=True
+        )
+        self.assertEqual(logged, [])
+        self.assertEqual(msg.get("status"), "warning")
+
+
+class TestPullPagination(unittest.TestCase):
+    """Safaricom paginates; we used to import only the first page."""
+
+    def _walk(self, total_pages):
+        requested = []
+
+        def fake_request(**kwargs):
+            requested.append(int(kwargs["payload"]["OffSetValue"]))
+            kwargs["success_callback"](
+                response={"ResponseCode": "1000", "Response": [], "TotalPages": total_pages},
+                document_name=SETTINGS_NAME,
+                settings_name=SETTINGS_NAME,
+                integration_request=None,
+            )
+            return {"ResponseCode": "1000", "TotalPages": total_pages}
+
+        with patch.object(api, "process_request", side_effect=fake_request), patch.object(
+            api.frappe, "publish_realtime"
+        ), patch.object(handler.frappe, "get_doc", return_value=_StubSettings()), patch.object(
+            handler, "record_pull_outcome"
+        ), patch.object(handler.frappe, "log_error"):
+            api.execute_pull_transactions(
+                mpesa_settings=SETTINGS_NAME,
+                payload={"ShortCode": "898048", "OffSetValue": "0"},
+            )
+        return requested
+
+    def test_every_page_is_fetched(self):
+        self.assertEqual(self._walk(4), [0, 1, 2, 3])
+
+    def test_single_page_stops_immediately(self):
+        self.assertEqual(self._walk(1), [0])
+
+    def test_runaway_total_pages_is_capped(self):
+        self.assertEqual(len(self._walk(9999)), api.PULL_MAX_PAGES)

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/test_pull_transactions.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/test_pull_transactions.py
@@ -88,7 +88,7 @@ class TestPullTransactionResponses(unittest.TestCase):
         self.assertEqual(msg.get("count"), 0)
 
     def test_batch_mode_suppresses_the_per_shortcode_log(self):
-        """~69 shortcodes x 12 runs a day made these logs unreadable."""
+        """Dozens of shortcodes, pulled hourly, made these logs unreadable."""
         msg, logged = self._run(
             {"ResponseCode": "1001", "ResponseMessage": "No records found"}, batch=True
         )

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register_list.js
@@ -37,6 +37,30 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 			listview.refresh();
 		};
 		frappe.realtime.on("mpesa_transaction_status_update", window._mpesa_c2b_status_handler);
+
+		// The pull runs as a background job, so its result arrives here rather
+		// than in the button callback. Same window-scoped guard as above.
+		if (window._mpesa_c2b_pull_handler) {
+			frappe.realtime.off("mpesa_pull_transaction_complete", window._mpesa_c2b_pull_handler);
+		}
+		window._mpesa_c2b_pull_handler = (data) => {
+			frappe.hide_progress();
+			frappe.msgprint({
+				message: __(data.message),
+				title: __(data.title),
+				indicator:
+					data.status === "error"
+						? "red"
+						: data.status === "warning"
+						? "orange"
+						: "green",
+			});
+			if (data.count) {
+				listview.refresh();
+			}
+		};
+		frappe.realtime.on("mpesa_pull_transaction_complete", window._mpesa_c2b_pull_handler);
+
 		// Add a custom button to the page actions (top bar)
 		listview.page.add_inner_button(__("Check Transaction Status"), function () {
 			frappe.prompt(
@@ -133,6 +157,95 @@ frappe.listview_settings["Mpesa C2B Payment Register"] = {
 				},
 				__("Transaction Status Query"),
 				__("Submit")
+			);
+		});
+
+		// Same pull as Mpesa Settings > Pull Transactions, only it asks which
+		// account to use instead of taking it from the open document.
+		listview.page.add_inner_button(__("Pull Transactions"), function () {
+			const DATE_FORMAT = "YYYY-MM-DD HH:mm:ss";
+			const PULL_WINDOW_HOURS = 48;
+
+			frappe.prompt(
+				[
+					{
+						label: "Mpesa Settings",
+						fieldname: "mpesa_settings",
+						fieldtype: "Link",
+						options: "Mpesa Settings",
+						reqd: 1,
+					},
+					{
+						label: "End Date",
+						fieldname: "end_date",
+						fieldtype: "Datetime",
+						reqd: 1,
+						default: frappe.datetime.now_datetime(),
+						description: __(
+							"Pulls the 48 hours ending at this time. Transactions already recorded are skipped."
+						),
+					},
+				],
+				(values) => {
+					frappe.db.get_value(
+						"Mpesa Settings",
+						values.mpesa_settings,
+						"pull_transaction_nominated_number",
+						(settings) => {
+							if (!settings || !settings.pull_transaction_nominated_number) {
+								frappe.throw(
+									__(
+										"Please set the Pull Transaction Nominated Number on the selected Mpesa Settings and register before pulling."
+									)
+								);
+								return;
+							}
+
+							const start_date = moment(values.end_date, DATE_FORMAT)
+								.subtract(PULL_WINDOW_HOURS, "hours")
+								.format(DATE_FORMAT);
+
+							frappe.call({
+								method: "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.pull_transactions",
+								args: {
+									mpesa_settings: values.mpesa_settings,
+									start_date: start_date,
+									end_date: values.end_date,
+								},
+								freeze: true,
+								freeze_message: __("Pulling transactions from M-Pesa..."),
+								callback: (r) => {
+									if (!r.message) {
+										return;
+									}
+									if (r.message.status === "error") {
+										frappe.msgprint({
+											message: __(r.message.message),
+											title: __("Error"),
+											indicator: "red",
+										});
+									} else {
+										frappe.show_alert({
+											message: __(r.message.message),
+											indicator: "blue",
+										});
+									}
+								},
+								error: (err) => {
+									frappe.msgprint({
+										message: __("An error occurred: {0}", [
+											err.message || "Unknown error",
+										]),
+										title: __("Error"),
+										indicator: "red",
+									});
+								},
+							});
+						}
+					);
+				},
+				__("Pull Transactions"),
+				__("Pull")
 			);
 		});
 	},

--- a/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
+++ b/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
@@ -1,28 +1,50 @@
 import frappe
 from frappe.utils import add_to_date, now_datetime
+from frappe.utils.background_jobs import is_job_enqueued
 
-from frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api import pull_transactions
+HOURLY_PULL_JOB_ID = "mpesa_hourly_pull_transactions"
+HOURLY_PULL_WINDOW_HOURS = -2
 
 
 def run_hourly_pull_transactions():
+    """Pull every enabled shortcode in one job.
+
+    This used to enqueue one job per Mpesa Settings doc. With ~69 shortcodes
+    that meant 69 jobs an hour, each writing its own Error Log when Safaricom
+    answered 1001 - roughly 800 log entries a day, almost all of them just
+    "this branch took no payments in the last two hours". One job means one
+    summary entry per run.
+    """
     settings_list = frappe.get_all(
         "Mpesa Settings",
         filters={"enable_hourly_pull_transactions": 1},
         fields=["name"],
     )
-    end_date = now_datetime()
-    start_date = add_to_date(end_date, hours=-2)
+    if not settings_list:
+        return
 
-    for row in settings_list:
-        try:
-            pull_transactions(
-                mpesa_settings=row.name,
-                start_date=start_date.strftime("%Y-%m-%d %H:%M:%S"),
-                end_date=end_date.strftime("%Y-%m-%d %H:%M:%S"),
-                offset=0,
-            )
-        except Exception:
-            frappe.log_error(
-                frappe.get_traceback(),
-                f"[Hourly Pull Transaction Error] {row.name}",
-            )
+    # A slow run must not stack on top of itself - 69 shortcodes with retries
+    # can outlast the hour.
+    if is_job_enqueued(HOURLY_PULL_JOB_ID):
+        frappe.logger().info("Hourly Mpesa pull still running, skipping this cycle")
+        return
+
+    end_date = now_datetime()
+    start_date = add_to_date(end_date, hours=HOURLY_PULL_WINDOW_HOURS)
+
+    try:
+        frappe.enqueue(
+            "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api"
+            ".execute_bulk_pull_transactions",
+            queue="long",
+            timeout=3600,
+            job_id=HOURLY_PULL_JOB_ID,
+            settings_names=[row.name for row in settings_list],
+            start_date=start_date.strftime("%Y-%m-%d %H:%M:%S"),
+            end_date=end_date.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+    except Exception:
+        frappe.log_error(
+            frappe.get_traceback(),
+            "[Hourly Pull Transaction Error] could not queue bulk pull",
+        )

--- a/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
+++ b/frappe_mpsa_payments/services/b2c_pull_transaction_scheduler_service.py
@@ -9,9 +9,9 @@ HOURLY_PULL_WINDOW_HOURS = -2
 def run_hourly_pull_transactions():
     """Pull every enabled shortcode in one job.
 
-    This used to enqueue one job per Mpesa Settings doc. With ~69 shortcodes
-    that meant 69 jobs an hour, each writing its own Error Log when Safaricom
-    answered 1001 - roughly 800 log entries a day, almost all of them just
+    This used to enqueue one job per Mpesa Settings doc. With dozens of
+    shortcodes that meant dozens of jobs an hour, each writing its own Error
+    Log when Safaricom answered 1001 - hundreds of entries a day, almost all just
     "this branch took no payments in the last two hours". One job means one
     summary entry per run.
     """
@@ -23,8 +23,8 @@ def run_hourly_pull_transactions():
     if not settings_list:
         return
 
-    # A slow run must not stack on top of itself - 69 shortcodes with retries
-    # can outlast the hour.
+    # A slow run must not stack on top of itself - dozens of shortcodes with
+    # retries can outlast the hour.
     if is_job_enqueued(HOURLY_PULL_JOB_ID):
         frappe.logger().info("Hourly Mpesa pull still running, skipping this cycle")
         return


### PR DESCRIPTION
The hourly pull job enqueued one job per Mpesa Settings doc. On a bench carrying dozens of shortcodes that is dozens of jobs an hour, each writing its own Error Log when Safaricom answers 1001 — hundreds of entries a day, almost all of them just "this shortcode took no payments in the last two hours".

It now runs as a single job writing one summary that lists every shortcode with no data, and one log per pull rather than one per transaction. `last_pull_status` and the related fields still record per shortcode, so nothing is lost.

Also walks Safaricom pagination properly. A busy shortcode over a 48h window can return several hundred records across several pages; previously only the first page was imported unless someone manually re-ran with each offset.

Adds a Pull Transactions button to the C2B Payment Register list view, with a realtime completion listener.

The last commit is unrelated tidying: a few comments and docstrings quoted shortcode counts and record totals from one particular deployment. The point they make holds at any scale, so they now say it that way.

Seven tests, all passing.