### PR TITLE
Fix STK push failing when there is no linked document

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -296,7 +296,15 @@ def initiate_stk_push(**args) -> any:
         amount = args.request_amount
         business_shortcode = mpesa_settings.business_shortcode
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-        reference_name = args.get("reference_name", "Online Payment")
+        # A standalone push - phone number and amount, no linked document - still
+        # sends the reference_name key, with None as its value. dict.get() only
+        # falls back to the default when the key is *absent*, so the default never
+        # applied here and Daraja rejected the null with "Invalid Remarks".
+        reference_name = (
+            args.get("reference_name")
+            or args.get("document_name")
+            or "Online Payment"
+        )
 
         payload = {
             "BusinessShortCode": business_shortcode,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -296,12 +296,18 @@ def initiate_stk_push(**args) -> any:
         amount = args.request_amount
         business_shortcode = mpesa_settings.business_shortcode
         timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-        # A standalone push - phone number and amount, no linked document - still
-        # sends the reference_name key, with None as its value. dict.get() only
-        # falls back to the default when the key is *absent*, so the default never
-        # applied here and Daraja rejected the null with "Invalid Remarks".
-        reference_name = (
-            args.get("reference_name")
+        # AccountReference is the Pay Bill account number: the string the payment
+        # shows against on the customer's statement, and what comes back as
+        # BillRefNumber for reconciliation. Prefer the caller's own reference - a
+        # POS sets one before the invoice exists - then the linked document.
+        #
+        # Every caller sends these keys even when their value is None, and
+        # dict.get() only falls back when a key is *absent*, so each step has to
+        # be an `or`. Sending a null here is what Daraja rejects with
+        # 400.002.02 "Bad Request - Invalid Remarks".
+        account_reference = (
+            args.get("account_reference")
+            or args.get("reference_name")
             or args.get("document_name")
             or "Online Payment"
         )
@@ -319,8 +325,8 @@ def initiate_stk_push(**args) -> any:
             ),
             "PhoneNumber": int(mobile_number),
             "CallBackURL": callback_url,
-            "AccountReference": reference_name,
-            "TransactionDesc": reference_name,
+            "AccountReference": account_reference,
+            "TransactionDesc": account_reference,
             "TransactionType": (
                 "CustomerPayBillOnline"
                 if mpesa_settings.paybill_type == "Pay Bill"

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/test_m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/test_m_pesa_api.py
@@ -4,9 +4,10 @@ from frappe.tests.utils import FrappeTestCase
 
 from .m_pesa_api import (
     confirmation,
-    get_mpesa_draft_payments,
+    get_mpesa_draft_c2b_payments,
     get_mpesa_mode_of_payment,
     get_token,
+    initiate_stk_push,
     submit_mpesa_payment,
     validation,
 )
@@ -60,6 +61,95 @@ class TestMPesaAPI(FrappeTestCase):
         self.assertEqual(result["ResultCode"], 0)
         self.assertEqual(result["ResultDesc"], "Accepted")
 
+    def _stk_payload(self, mock_process, **overrides):
+        """Fire initiate_stk_push with process_request stubbed, return the payload."""
+        args = {
+            "payment_gateway": "Mpesa-898102",
+            "phone_number": "254727870777",
+            "request_amount": 1,
+            "doctype": "Mpesa Express Request",
+            "document_name": "MEXP-26-08-000004",
+        }
+        args.update(overrides)
+
+        initiate_stk_push(**args)
+
+        self.assertTrue(
+            mock_process.called,
+            "process_request was never reached - the push was not built",
+        )
+        return mock_process.call_args.kwargs["payload"]
+
+    @patch("frappe.get_doc")
+    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url")
+    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_request")
+    def test_stk_push_account_reference_never_null(
+        self, mock_process, mock_callback, mock_get_doc
+    ):
+        """A standalone push - no linked document - must still carry a reference.
+
+        Regression: initiate_request() always passes the reference_name key, with
+        None as its value for a push that isn't tied to an invoice. dict.get()
+        only falls back to its default when the key is absent, so the default
+        never applied and Daraja rejected the null AccountReference with
+        400.002.02 "Bad Request - Invalid Remarks".
+        """
+        mock_callback.return_value = "https://example.com/callback"
+        settings = Mock()
+        settings.name = "898102"
+        settings.business_shortcode = "898102"
+        settings.paybill_type = "Pay Bill"
+        settings.get_password.return_value = "passkey"
+        mock_get_doc.return_value = settings
+
+        # reference_name present but None - the exact shape initiate_request sends.
+        payload = self._stk_payload(mock_process, reference_name=None)
+
+        self.assertIsNotNone(payload["AccountReference"])
+        self.assertIsNotNone(payload["TransactionDesc"])
+        self.assertEqual(payload["AccountReference"], "MEXP-26-08-000004")
+        self.assertEqual(payload["TransactionDesc"], "MEXP-26-08-000004")
+
+    @patch("frappe.get_doc")
+    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url")
+    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_request")
+    def test_stk_push_reference_name_wins_over_document_name(
+        self, mock_process, mock_callback, mock_get_doc
+    ):
+        """A linked document still supplies the reference - unchanged behaviour."""
+        mock_callback.return_value = "https://example.com/callback"
+        settings = Mock()
+        settings.name = "898102"
+        settings.business_shortcode = "898102"
+        settings.paybill_type = "Pay Bill"
+        settings.get_password.return_value = "passkey"
+        mock_get_doc.return_value = settings
+
+        payload = self._stk_payload(mock_process, reference_name="SINV-00042")
+
+        self.assertEqual(payload["AccountReference"], "SINV-00042")
+
+    @patch("frappe.get_doc")
+    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url")
+    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_request")
+    def test_stk_push_falls_back_when_nothing_identifies_the_push(
+        self, mock_process, mock_callback, mock_get_doc
+    ):
+        """With neither reference nor document name, fall back to a literal."""
+        mock_callback.return_value = "https://example.com/callback"
+        settings = Mock()
+        settings.name = "898102"
+        settings.business_shortcode = "898102"
+        settings.paybill_type = "Pay Bill"
+        settings.get_password.return_value = "passkey"
+        mock_get_doc.return_value = settings
+
+        payload = self._stk_payload(
+            mock_process, reference_name=None, document_name=None
+        )
+
+        self.assertEqual(payload["AccountReference"], "Online Payment")
+
     @patch("frappe.get_all")
     def test_get_mpesa_mode_of_payment(self, mock_get_all):
         mock_get_all.return_value = [{"mode_of_payment": "Cash"}]
@@ -77,7 +167,9 @@ class TestMPesaAPI(FrappeTestCase):
         company = "Test Company"
         mode_of_payment = "Cash"
 
-        payments = get_mpesa_draft_payments(company, mode_of_payment)
+        payments = get_mpesa_draft_c2b_payments(
+            company, mode_of_payment=mode_of_payment
+        )
 
         self.assertEqual(len(payments), 1)
         self.assertEqual(payments[0]["name"], "MP001")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/test_m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/test_m_pesa_api.py
@@ -63,12 +63,15 @@ class TestMPesaAPI(FrappeTestCase):
 
     def _stk_payload(self, mock_process, **overrides):
         """Fire initiate_stk_push with process_request stubbed, return the payload."""
+        # Mirrors initiate_request(): every key is sent, None included.
         args = {
             "payment_gateway": "Mpesa-898102",
             "phone_number": "254727870777",
             "request_amount": 1,
             "doctype": "Mpesa Express Request",
             "document_name": "MEXP-26-08-000004",
+            "reference_name": None,
+            "account_reference": None,
         }
         args.update(overrides)
 
@@ -81,7 +84,9 @@ class TestMPesaAPI(FrappeTestCase):
         return mock_process.call_args.kwargs["payload"]
 
     @patch("frappe.get_doc")
-    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url")
+    @patch(
+        "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url"
+    )
     @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_request")
     def test_stk_push_account_reference_never_null(
         self, mock_process, mock_callback, mock_get_doc
@@ -111,7 +116,9 @@ class TestMPesaAPI(FrappeTestCase):
         self.assertEqual(payload["TransactionDesc"], "MEXP-26-08-000004")
 
     @patch("frappe.get_doc")
-    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url")
+    @patch(
+        "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url"
+    )
     @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_request")
     def test_stk_push_reference_name_wins_over_document_name(
         self, mock_process, mock_callback, mock_get_doc
@@ -130,7 +137,39 @@ class TestMPesaAPI(FrappeTestCase):
         self.assertEqual(payload["AccountReference"], "SINV-00042")
 
     @patch("frappe.get_doc")
-    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url")
+    @patch(
+        "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url"
+    )
+    @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_request")
+    def test_stk_push_prefers_caller_supplied_account_reference(
+        self, mock_process, mock_callback, mock_get_doc
+    ):
+        """The Pay Bill account number wins over anything we could infer.
+
+        A POS supplies this before the sale exists as a document, and it is what
+        the customer's statement shows and what returns as BillRefNumber.
+        """
+        mock_callback.return_value = "https://example.com/callback"
+        settings = Mock()
+        settings.name = "898102"
+        settings.business_shortcode = "898102"
+        settings.paybill_type = "Pay Bill"
+        settings.get_password.return_value = "passkey"
+        mock_get_doc.return_value = settings
+
+        payload = self._stk_payload(
+            mock_process,
+            account_reference="ACC-2026-001",
+            reference_name="SINV-00042",
+        )
+
+        self.assertEqual(payload["AccountReference"], "ACC-2026-001")
+        self.assertEqual(payload["TransactionDesc"], "ACC-2026-001")
+
+    @patch("frappe.get_doc")
+    @patch(
+        "frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.build_callback_url"
+    )
     @patch("frappe_mpsa_payments.frappe_mpsa_payments.api.m_pesa_api.process_request")
     def test_stk_push_falls_back_when_nothing_identifies_the_push(
         self, mock_process, mock_callback, mock_get_doc

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
@@ -112,6 +112,7 @@ class MpesaExpressRequest(Document):
             "doctype": self.doctype,
             "document_name": self.name,
             "reference_name": self.reference_name,
+            "account_reference": self.account_reference,
         }
 
         try:

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/test_mpesa_express_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/test_mpesa_express_request.py
@@ -1,9 +1,51 @@
 # Copyright (c) 2025, Navari Limited and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+PUSH = (
+    "frappe_mpsa_payments.frappe_mpsa_payments.doctype"
+    ".mpesa_express_request.mpesa_express_request.initiate_stk_push"
+)
 
 
 class TestMpesaExpressRequest(FrappeTestCase):
-	pass
+    def _draft(self, **fields):
+        doc = frappe.new_doc("Mpesa Express Request")
+        doc.name = "MEXP-TEST-0001"
+        doc.payment_gateway = "Mpesa-898102"
+        doc.phone_number = "254727870777"
+        doc.amount = 1
+        doc.update(fields)
+        return doc
+
+    @patch(PUSH)
+    def test_initiate_request_forwards_account_reference(self, mock_push):
+        """The Pay Bill account number has to reach the push, not just the doc.
+
+        Regression: a POS could set account_reference and see it stored, while
+        initiate_request() never forwarded it, so Safaricom was sent the request
+        name instead and the account number never reached the statement.
+        """
+        self._draft(account_reference="ACC-2026-001").initiate_request()
+
+        self.assertEqual(
+            mock_push.call_args.kwargs.get("account_reference"), "ACC-2026-001"
+        )
+
+    @patch(PUSH)
+    def test_initiate_request_forwards_all_reference_candidates(self, mock_push):
+        """Whatever the push falls back to, initiate_request must supply it."""
+        doc = self._draft(
+            account_reference=None,
+            reference_doctype="Sales Invoice",
+            reference_name="SINV-00042",
+        )
+        doc.initiate_request()
+
+        kwargs = mock_push.call_args.kwargs
+        self.assertEqual(kwargs.get("reference_name"), "SINV-00042")
+        self.assertEqual(kwargs.get("document_name"), "MEXP-TEST-0001")


### PR DESCRIPTION
STK pushes carrying just a phone number and an amount were rejected by Daraja with `400.002.02 "Bad Request - Invalid Remarks"`.

`initiate_request()` always passes the `reference_name` key. When the push is not tied to an invoice its value is `None`, and `dict.get()` only falls back to its default when the key is *absent* — so `AccountReference` and `TransactionDesc` went out as null.

This broke the desk form, POS quick pay and the API. Pushes tied to an invoice were unaffected, which is why it went unnoticed.

A second gap: `account_reference` was stored on the request and used for duplicate prevention, but never forwarded to Safaricom, so a Pay Bill account number supplied by a caller could not reach the customer statement or return as BillRefNumber.

Order is now: account reference, then linked document, then request name, then a literal.

Verified end to end against a live paybill — a real payment completed, and a caller-supplied account reference was confirmed in the payload Safaricom received.

Six regression tests, each mutation-checked by reverting the fix and confirming the expected tests fail.