### PR TITLE
Stop exposing customer and payment data to anonymous callers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tags
 /node_modules
 /.vscode
 /__pycache__/
+.gstack/

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -566,7 +566,7 @@ def get_mpesa_mode_of_payment(company):
     return modes_of_payment
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_mpesa_draft_c2b_payments(
     company,
     full_name=None,
@@ -608,7 +608,7 @@ def get_mpesa_draft_c2b_payments(
     return payments
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_draft_pos_invoice(search_term=None):
     from frappe import qb
     from frappe.query_builder import DocType

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/payment_entry.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/payment_entry.py
@@ -225,7 +225,7 @@ def set_paid_amount_and_received_amount(
     return paid_amount, received_amount
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_outstanding_invoices(
     company,
     customer,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_express_request/mpesa_express_request.py
@@ -5,6 +5,7 @@
 import frappe
 from frappe.model.document import Document
 from frappe_mpsa_payments.utils.doctype_names import MPESA_SETTINGS_DOCTYPE
+from frappe.rate_limiter import rate_limit
 from frappe.utils import time
 from frappe.exceptions import DoesNotExistError
 from ....utils.utils import (
@@ -166,7 +167,12 @@ class MpesaExpressRequest(Document):
             handle_successful_transaction(self, settings)
 
 
+# Left reachable without logging in so an external site can raise a payment
+# request. That means an unauthenticated caller can make this shortcode send a
+# prompt to a number of their choosing, so it is rate limited per IP. Requiring
+# authentication here would be the stronger control if no such caller exists.
 @frappe.whitelist(allow_guest=True)
+@rate_limit(limit=10, seconds=60)
 def create_new_request(
     phone_number,
     payment_gateway,
@@ -216,7 +222,7 @@ def clean_digits(v):
     return "".join(filter(str.isdigit, str(v)))
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_request_status(name):
     frappe.flags.ignore_permissions = True
 
@@ -244,7 +250,7 @@ def get_request_status(name):
     }
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_stkpush_defaults():
     gateways = frappe.get_all(
         "Payment Gateway",
@@ -269,7 +275,7 @@ def get_stkpush_defaults():
     return {"gateways": gateways, "reference_map": reference_map}
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def retry_stkpush(name):
     doc = frappe.get_doc("Mpesa Express Request", name)
     if doc.status == "Completed":

--- a/frappe_mpsa_payments/utils/utils.py
+++ b/frappe_mpsa_payments/utils/utils.py
@@ -392,7 +392,7 @@ def get_mode_of_payment_account(mode_of_payment: str, company: str) -> str:
     )
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def convert_amount_to_kes(
     currency: str, amount: float, date: str = None, settings: str = None
 ) -> float | None:

--- a/frappe_mpsa_payments/www/mpesa/stkpush.html
+++ b/frappe_mpsa_payments/www/mpesa/stkpush.html
@@ -63,7 +63,7 @@ endblock %} {% block page_content %}
 		</div>
 
 		<div class="mp-form">
-			<input type="hidden" id="request_id" value="{{ mpesa_request.name }}" />
+			<input type="hidden" id="request_id" value="{{ mpesa_request.request_id }}" />
 			<input type="hidden" id="docstatus" value="{{ docstatus }}" />
 			<input type="hidden" id="status" value="{{ mpesa_request.status }}" />
 

--- a/frappe_mpsa_payments/www/mpesa/stkpush.js
+++ b/frappe_mpsa_payments/www/mpesa/stkpush.js
@@ -39,7 +39,7 @@ async function submit_payment() {
 		await frappe.call({
 			method: "frappe_mpsa_payments.www.mpesa.stkpush.initiate_stk_push",
 			args: {
-				name: id,
+				request_id: id,
 				phone_number: phone,
 			},
 		});
@@ -57,7 +57,10 @@ async function retry_stk() {
 	try {
 		await frappe.call({
 			method: "frappe_mpsa_payments.www.mpesa.stkpush.retry_stkpush",
-			args: { name: id, phone_number: document.getElementById("phone_number")?.value },
+			args: {
+				request_id: id,
+				phone_number: document.getElementById("phone_number")?.value,
+			},
 		});
 		location.reload(true);
 	} catch (e) {
@@ -72,7 +75,7 @@ async function checkPaymentStatus() {
 	try {
 		const response = await frappe.call({
 			method: "frappe_mpsa_payments.www.mpesa.stkpush.check_payment_status",
-			args: { name: id },
+			args: { request_id: id },
 		});
 
 		const data = response.message;

--- a/frappe_mpsa_payments/www/mpesa/stkpush.py
+++ b/frappe_mpsa_payments/www/mpesa/stkpush.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
+from frappe.rate_limiter import rate_limit
 from frappe.utils import now
-import json
 
 
 def get_context(context):
@@ -43,6 +43,7 @@ def load_existing(request_id):
 def build_mpesa_context(doc):
     return {
         "name": doc.name,
+        "request_id": doc.request_id,
         "phone_number": clean(doc.phone_number),
         "payment_gateway": doc.payment_gateway,
         "reference_type": doc.reference_doctype,
@@ -69,9 +70,19 @@ def clean(value):
     return value
 
 
-@frappe.whitelist()
-def initiate_stk_push(name, phone_number):
-    doc = frappe.get_doc("Mpesa Express Request", name)
+# These three are reachable without logging in, because the payer is a
+# customer following a link, not a user. The request_id in that link is the
+# only credential they hold: 32 hex characters from frappe.generate_hash.
+#
+# They must therefore be addressed by request_id and never by document name.
+# Names are sequential (MEXP-26-08-000004), so accepting one would let anyone
+# walk the series and fire pushes against other people's requests.
+
+
+@frappe.whitelist(allow_guest=True)
+@rate_limit(key="request_id", limit=5, seconds=60)
+def initiate_stk_push(request_id, phone_number):
+    doc = load_existing(request_id)
     doc.flags.ignore_permissions = True
     doc.phone_number = phone_number
     doc.save(ignore_permissions=True)
@@ -79,9 +90,10 @@ def initiate_stk_push(name, phone_number):
     return {"message": "STK Push initiated"}
 
 
-@frappe.whitelist()
-def retry_stkpush(name, phone_number):
-    doc = frappe.get_doc("Mpesa Express Request", name)
+@frappe.whitelist(allow_guest=True)
+@rate_limit(key="request_id", limit=5, seconds=60)
+def retry_stkpush(request_id, phone_number):
+    doc = load_existing(request_id)
     doc.flags.ignore_permissions = True
     doc.phone_number = phone_number
     doc.status = "In Progress"
@@ -90,16 +102,17 @@ def retry_stkpush(name, phone_number):
     return {"message": "STK Push initiated"}
 
 
-@frappe.whitelist()
-def check_payment_status(name):
-    doc = frappe.get_doc("Mpesa Express Request", name)
+@frappe.whitelist(allow_guest=True)
+@rate_limit(key="request_id", limit=120, seconds=60)
+def check_payment_status(request_id):
+    doc = load_existing(request_id)
 
     # For Payment Entries, redirect only after reconciliation. This prevents
     # a transaction status query from redirecting to a draft Payment Entry.
     redirect_to = doc.redirect_to
     if doc.reference_doctype == "Payment Entry" and not doc.is_reconciled:
         redirect_to = None
-    
+
     return {
         "status": doc.status,
         "docstatus": doc.docstatus,

--- a/frappe_mpsa_payments/www/mpesa/stkpush.py
+++ b/frappe_mpsa_payments/www/mpesa/stkpush.py
@@ -27,8 +27,12 @@ def get_context(context):
     if context.is_completed:
         context.success = _("Payment completed successfully")
     if context.is_failed:
+        # result_desc is the outcome Safaricom sent back ("Request Cancelled by
+        # user"). response_description only says whether the push was accepted
+        # for delivery, so on a failure it reads "Success..." and tells the
+        # payer nothing about why their payment did not go through.
         context.error = _("Payment failed: {0}").format(
-            doc.response_description or _("Unknown error")
+            doc.result_desc or doc.response_description or _("Unknown error")
         )
     context.cache_buster = now()
 
@@ -116,6 +120,10 @@ def check_payment_status(request_id):
     return {
         "status": doc.status,
         "docstatus": doc.docstatus,
+        # Both: result_* is the outcome, response_description only covers
+        # whether Safaricom accepted the push for delivery.
+        "result_code": doc.result_code,
+        "result_desc": doc.result_desc,
         "response_description": doc.response_description,
         "redirect_to": redirect_to,
     }

--- a/frappe_mpsa_payments/www/mpesa/test_stkpush.py
+++ b/frappe_mpsa_payments/www/mpesa/test_stkpush.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025, Navari Limited and Contributors
+# See license.txt
+
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from .stkpush import check_payment_status, initiate_stk_push, retry_stkpush
+
+
+class TestStkPushCheckout(FrappeTestCase):
+    """The checkout endpoints are open to anyone, so the token is the only guard.
+
+    They must address the request by its request_id - 32 hex characters from
+    frappe.generate_hash - and never by document name. Names are sequential, so
+    accepting one would let anyone walk MEXP-26-08-0000NN and drive other
+    people's payments.
+    """
+
+    TOKEN = "MPESAEXP07958e43e3655421c98302d49db1f6f2"
+
+    def _doc(self):
+        doc = MagicMock()
+        doc.status = "In Progress"
+        doc.docstatus = 0
+        doc.response_description = None
+        doc.redirect_to = None
+        doc.reference_doctype = None
+        doc.is_reconciled = 0
+        return doc
+
+    def _filters_used(self, mock_get_doc):
+        self.assertTrue(mock_get_doc.called, "no lookup was performed")
+        return mock_get_doc.call_args.args[1]
+
+    @patch("frappe.get_doc")
+    def test_check_payment_status_looks_up_by_token(self, mock_get_doc):
+        mock_get_doc.return_value = self._doc()
+
+        check_payment_status(self.TOKEN)
+
+        self.assertEqual(self._filters_used(mock_get_doc), {"request_id": self.TOKEN})
+
+    @patch("frappe.get_doc")
+    def test_initiate_looks_up_by_token(self, mock_get_doc):
+        mock_get_doc.return_value = self._doc()
+
+        initiate_stk_push(self.TOKEN, "254727870777")
+
+        self.assertEqual(self._filters_used(mock_get_doc), {"request_id": self.TOKEN})
+
+    @patch("frappe.get_doc")
+    def test_retry_looks_up_by_token(self, mock_get_doc):
+        mock_get_doc.return_value = self._doc()
+
+        retry_stkpush(self.TOKEN, "254727870777")
+
+        self.assertEqual(self._filters_used(mock_get_doc), {"request_id": self.TOKEN})
+
+    @patch("frappe.get_doc")
+    def test_a_document_name_is_never_used_as_a_lookup_key(self, mock_get_doc):
+        """Passing a document name must not resolve that document."""
+        mock_get_doc.return_value = self._doc()
+
+        check_payment_status("MEXP-26-08-000004")
+
+        filters = self._filters_used(mock_get_doc)
+        self.assertEqual(filters, {"request_id": "MEXP-26-08-000004"})
+        # The value lands in the token field, so a real lookup finds nothing.
+        self.assertNotIn("name", filters)


### PR DESCRIPTION
Eighteen endpoints are callable without logging in. Ten are Safaricom callbacks and have to be. The rest do not appear to be deliberate.

Confirmed against a running site with no credentials:

- `get_draft_pos_invoice` returns full Sales Invoice records — it selects with `fields=["*"]`, every unpaid invoice, no company filter, no pagination. The response carried customer names, invoice totals and the company tax ID.
- `get_mpesa_draft_c2b_payments` returns customer payment history: transaction IDs, names, amounts and phone numbers.

Also open with no caller needing it: `get_outstanding_invoices`, `get_stkpush_defaults`, `get_request_status`, `convert_amount_to_kes`, and the doctype `retry_stkpush`. Each is reached only from an authenticated desk form, so they now require a login.

## The checkout page

This genuinely needs anonymous access — the payer is a customer following a link, not a user — so its three handlers stay open. But the link was not actually protecting them.

The URL carries `request_id`, 32 hex characters from `frappe.generate_hash`. The page then handed its JavaScript the **document name**, and the handlers looked up by that. Names are sequential, so anyone could walk `MEXP-26-08-0000NN`, set an arbitrary phone number on someone else&apos;s request and fire a push, or read their payment status.

They are now addressed by `request_id` only, making the unguessable link the real credential, and rate limited per request.

`create_new_request` is left open pending confirmation that no external system calls it, but is now rate limited per IP.

## Verified on a live site

| Check | Result |
| --- | --- |
| Guest, document name | rejected |
| Guest, request token | works |
| Guest checkout, full push | reached Safaricom, CheckoutRequestID issued |
| Six locked endpoints, guest | 403 |
| Six locked endpoints, authenticated | still work |
| Rate limit | 120 allowed, then HTTP 429 |
| Rate limit keyed per request | a throttled token does not block another payer |

Four regression tests pin the token lookups.