### PR TITLE
Make the Reconciliation Priority table actually drive matching

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register.py
@@ -209,15 +209,25 @@ class MpesaC2BPaymentRegister(Document):
                 )
 
     def _reconciliation_order(self) -> list[tuple[str, str]]:
-        """The configured priority for this shortcode, newest config winning.
+        """The configured priority for this shortcode.
 
-        Falls back to the historical hardcoded order when nothing is set, so an
-        unconfigured install is unaffected.
+        Falls back to the historical hardcoded order when the table is empty,
+        so an unconfigured install is unaffected.
+
+        The table only appears in the form while auto_reconcile_c2b is on, so
+        it stays dormant while that is off - otherwise rows left behind by
+        someone who disabled auto reconciliation would quietly keep steering
+        customer resolution, which runs whether or not the toggle is set.
         """
-        settings_name = frappe.db.get_value(
+        settings = frappe.db.get_value(
             "Mpesa Settings",
             {"business_shortcode": self.businessshortcode},
-            "name",
+            ["name", "auto_reconcile_c2b"],
+            as_dict=True,
+        )
+
+        settings_name = (
+            settings.name if settings and settings.auto_reconcile_c2b else None
         )
 
         rows = []

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/mpesa_c2b_payment_register.py
@@ -11,6 +11,24 @@ from frappe_mpsa_payments.frappe_mpsa_payments.api.payment_entry import (
     get_outstanding_invoices,
 )
 
+# Used when Mpesa Settings has no Reconciliation Priority rows. Reproduces the
+# order this matching was hardcoded to before the table drove it, so an install
+# that never configured the table keeps behaving the same.
+DEFAULT_RECONCILIATION_ORDER = (
+    ("Sales Invoice", "name"),
+    ("Sales Order", "name"),
+    ("Quotation", "name"),
+    ("Customer", "name"),
+)
+
+# Where a matched document names its customer. Anything not listed is assumed
+# to carry a plain `customer` field.
+CUSTOMER_FIELD_BY_DOCTYPE = {
+    "Customer": "name",
+    "Quotation": "party_name",
+}
+DEFAULT_CUSTOMER_FIELD = "customer"
+
 
 class MpesaC2BPaymentRegister(Document):
     def before_insert(self):
@@ -190,22 +208,83 @@ class MpesaC2BPaymentRegister(Document):
                     f"Failed to cancel Payment Entry {self.payment_entry} for C2B {self.name}",
                 )
 
+    def _reconciliation_order(self) -> list[tuple[str, str]]:
+        """The configured priority for this shortcode, newest config winning.
+
+        Falls back to the historical hardcoded order when nothing is set, so an
+        unconfigured install is unaffected.
+        """
+        settings_name = frappe.db.get_value(
+            "Mpesa Settings",
+            {"business_shortcode": self.businessshortcode},
+            "name",
+        )
+
+        rows = []
+        if settings_name:
+            rows = [
+                (row.target_doctype, row.match_field or "name")
+                for row in frappe.get_all(
+                    "Mpesa Reconciliation Priority",
+                    filters={
+                        "parent": settings_name,
+                        "parenttype": "Mpesa Settings",
+                    },
+                    fields=["target_doctype", "match_field"],
+                    order_by="idx asc",
+                )
+                if row.target_doctype
+            ]
+
+        return rows or list(DEFAULT_RECONCILIATION_ORDER)
+
+    def _match_filters(self, doctype: str, match_field: str) -> dict:
+        filters = {match_field: self.billrefnumber}
+
+        meta = frappe.get_meta(doctype)
+        if meta.is_submittable:
+            filters["docstatus"] = 1
+
+        # A Quotation can be addressed to a Lead, whose party_name is not a
+        # Customer. Only Customer quotations can name one.
+        if doctype == "Quotation" and meta.has_field("quotation_to"):
+            filters["quotation_to"] = "Customer"
+
+        return filters
+
+    def _usable_match(self, doctype: str, match_field: str) -> tuple[str, str] | None:
+        """Guard a configured row against a doctype or field that no longer exists."""
+        if not doctype:
+            return None
+
+        try:
+            meta = frappe.get_meta(doctype)
+        except Exception:
+            # A configured row can outlive the doctype or app it points at.
+            return None
+
+        if match_field != "name" and not meta.has_field(match_field):
+            return None
+
+        customer_field = CUSTOMER_FIELD_BY_DOCTYPE.get(doctype, DEFAULT_CUSTOMER_FIELD)
+        if customer_field != "name" and not meta.has_field(customer_field):
+            return None
+
+        return match_field, customer_field
+
     def _find_customer_from_billref(self, billrefnumber: str) -> str | None:
         if not billrefnumber:
             return
 
-        sources = [
-            ("Sales Invoice", "customer", {"docstatus": 1}),
-            ("Sales Order", "customer", {"docstatus": 1}),
-            ("Quotation", "party_name", {"docstatus": 1, "quotation_to": "Customer"}),
-            ("Customer", "name", {}),
-        ]
+        for doctype, match_field in self._reconciliation_order():
+            usable = self._usable_match(doctype, match_field)
+            if not usable:
+                continue
 
-        for doctype, customer_field, extra_filters in sources:
-            filters = {"name": billrefnumber}
-            filters.update(extra_filters)
-
-            customer = frappe.db.get_value(doctype, filters, customer_field)
+            match_field, customer_field = usable
+            customer = frappe.db.get_value(
+                doctype, self._match_filters(doctype, match_field), customer_field
+            )
             if customer:
                 self.customer = customer
                 return
@@ -239,25 +318,35 @@ class MpesaC2BPaymentRegister(Document):
         """
         Returns a tuple (invoice, sales_order), where exactly one is non-None if billrefnumber matched either.
         Otherwise both are None.
-        """
-        invoice = self._find_matching_invoice()
-        if invoice:
-            return invoice, None
 
-        order = self._find_matching_sales_order()
-        if order:
-            return None, order
+        Walks the configured Reconciliation Priority in order. Rows targeting
+        anything we cannot settle a payment against are skipped here; they still
+        count for customer resolution.
+        """
+        for doctype, match_field in self._reconciliation_order():
+            if not self._usable_match(doctype, match_field):
+                continue
+
+            if doctype == "Sales Invoice":
+                invoice = self._find_matching_invoice(match_field)
+                if invoice:
+                    return invoice, None
+
+            elif doctype == "Sales Order":
+                order = self._find_matching_sales_order(match_field)
+                if order:
+                    return None, order
 
         return None, None
 
-    def _find_matching_invoice(self):
+    def _find_matching_invoice(self, match_field: str = "name"):
         if not self.billrefnumber:
             return None
 
         return frappe.get_value(
             "Sales Invoice",
             {
-                "name": self.billrefnumber,
+                match_field: self.billrefnumber,
                 "docstatus": 1,
                 "company": self.company,
                 "customer": self.customer,
@@ -266,14 +355,14 @@ class MpesaC2BPaymentRegister(Document):
             "name",
         )
 
-    def _find_matching_sales_order(self):
+    def _find_matching_sales_order(self, match_field: str = "name"):
         if not self.billrefnumber:
             return None
 
         return frappe.get_value(
             "Sales Order",
             {
-                "name": self.billrefnumber,
+                match_field: self.billrefnumber,
                 "docstatus": 1,
                 "company": self.company,
                 "customer": self.customer,

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/test_mpesa_c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/test_mpesa_c2b_payment_register.py
@@ -65,6 +65,25 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
                 doc._reconciliation_order(), list(DEFAULT_RECONCILIATION_ORDER)
             )
 
+    def test_table_is_dormant_while_auto_reconcile_is_off(self):
+        """Rows left behind by someone who disabled auto reconciliation must
+        not keep steering matching. The field is only shown while the toggle
+        is on, so it should only apply while the toggle is on."""
+        doc = self._register()
+        rows = [frappe._dict(target_doctype="Customer", match_field="tax_id")]
+
+        with (
+            patch(
+                "frappe.db.get_value",
+                return_value=frappe._dict(name="SHORTCODE", auto_reconcile_c2b=0),
+            ),
+            patch("frappe.get_all", return_value=rows) as mock_get_all,
+        ):
+            order = doc._reconciliation_order()
+
+        self.assertEqual(order, list(DEFAULT_RECONCILIATION_ORDER))
+        self.assertFalse(mock_get_all.called, "configured rows were read anyway")
+
     def test_fallback_issues_exactly_the_original_queries(self):
         """Characterisation: an unconfigured install must query as it always did.
 
@@ -108,7 +127,10 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         ]
 
         with (
-            patch("frappe.db.get_value", return_value="898102"),
+            patch(
+                "frappe.db.get_value",
+                return_value=frappe._dict(name="SHORTCODE", auto_reconcile_c2b=1),
+            ),
             patch("frappe.get_all", return_value=rows),
         ):
             self.assertEqual(
@@ -121,7 +143,10 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         rows = [frappe._dict(target_doctype="Sales Order", match_field=None)]
 
         with (
-            patch("frappe.db.get_value", return_value="898102"),
+            patch(
+                "frappe.db.get_value",
+                return_value=frappe._dict(name="SHORTCODE", auto_reconcile_c2b=1),
+            ),
             patch("frappe.get_all", return_value=rows),
         ):
             self.assertEqual(doc._reconciliation_order(), [("Sales Order", "name")])

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/test_mpesa_c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/test_mpesa_c2b_payment_register.py
@@ -1,9 +1,136 @@
 # Copyright (c) 2024, Navari Limited and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from .mpesa_c2b_payment_register import DEFAULT_RECONCILIATION_ORDER
+
+MODULE = (
+    "frappe_mpsa_payments.frappe_mpsa_payments.doctype"
+    ".mpesa_c2b_payment_register.mpesa_c2b_payment_register"
+)
 
 
 class TestMpesaC2BPaymentRegister(FrappeTestCase):
-	pass
+    """The Reconciliation Priority table has to actually drive matching.
+
+    It used to be inert: `match_field` was never read by any Python, and the
+    order was hardcoded, so configuring the table changed nothing.
+    """
+
+    def setUp(self):
+        # get_meta hits the database on a cold cache, and these tests patch
+        # frappe.db.get_value out from under it. Warm the metas first so the
+        # patch only ever intercepts the lookups under test.
+        for doctype in ("Sales Invoice", "Sales Order", "Quotation", "Customer"):
+            frappe.get_meta(doctype)
+
+    def _register(self, **fields):
+        doc = frappe.new_doc("Mpesa C2B Payment Register")
+        doc.businessshortcode = "898102"
+        doc.billrefnumber = "ACC-001"
+        doc.company = "Dev Co"
+        doc.update(fields)
+        return doc
+
+    def _with_priority(self, rows):
+        """Patch the configured rows without touching Mpesa Settings."""
+        return patch.object(
+            frappe.model.document.Document,
+            "_reconciliation_order",
+            lambda _self: rows,
+            create=True,
+        )
+
+    def test_unconfigured_settings_keep_the_historical_order(self):
+        doc = self._register()
+
+        with patch("frappe.db.get_value", return_value=None), patch(
+            "frappe.get_all", return_value=[]
+        ):
+            self.assertEqual(doc._reconciliation_order(), list(DEFAULT_RECONCILIATION_ORDER))
+
+    def test_configured_rows_replace_the_default_order(self):
+        doc = self._register()
+        rows = [
+            frappe._dict(target_doctype="Customer", match_field="tax_id"),
+            frappe._dict(target_doctype="Sales Invoice", match_field="name"),
+        ]
+
+        with patch("frappe.db.get_value", return_value="898102"), patch(
+            "frappe.get_all", return_value=rows
+        ):
+            self.assertEqual(
+                doc._reconciliation_order(),
+                [("Customer", "tax_id"), ("Sales Invoice", "name")],
+            )
+
+    def test_a_row_without_a_match_field_falls_back_to_name(self):
+        doc = self._register()
+        rows = [frappe._dict(target_doctype="Sales Order", match_field=None)]
+
+        with patch("frappe.db.get_value", return_value="898102"), patch(
+            "frappe.get_all", return_value=rows
+        ):
+            self.assertEqual(doc._reconciliation_order(), [("Sales Order", "name")])
+
+    def test_configured_match_field_is_used_in_the_lookup(self):
+        """The whole point: a non-name match_field must reach the query."""
+        doc = self._register(billrefnumber="P051234567X")
+
+        with patch.object(
+            type(doc), "_reconciliation_order", lambda _self: [("Customer", "tax_id")]
+        ), patch("frappe.db.get_value", return_value="CUST-0001") as mock_get_value:
+            doc._find_customer_from_billref("P051234567X")
+
+        self.assertEqual(doc.customer, "CUST-0001")
+        filters = mock_get_value.call_args.args[1]
+        self.assertEqual(filters.get("tax_id"), "P051234567X")
+        self.assertNotIn("name", filters)
+
+    def test_priority_stops_at_the_first_hit(self):
+        doc = self._register()
+        order = [("Sales Invoice", "name"), ("Customer", "name")]
+
+        with patch.object(type(doc), "_reconciliation_order", lambda _self: order), patch(
+            "frappe.db.get_value", side_effect=["CUST-FROM-INVOICE", "CUST-FROM-CUSTOMER"]
+        ) as mock_get_value:
+            doc._find_customer_from_billref("ACC-001")
+
+        self.assertEqual(doc.customer, "CUST-FROM-INVOICE")
+        self.assertEqual(mock_get_value.call_count, 1)
+
+    def test_a_row_pointing_at_a_missing_doctype_is_skipped(self):
+        doc = self._register()
+        order = [("No Such Doctype", "name"), ("Customer", "name")]
+
+        with patch.object(type(doc), "_reconciliation_order", lambda _self: order), patch(
+            "frappe.db.get_value", return_value="CUST-0001"
+        ):
+            doc._find_customer_from_billref("ACC-001")
+
+        self.assertEqual(doc.customer, "CUST-0001")
+
+    def test_matching_refs_follow_the_configured_order(self):
+        """Sales Order first means an order wins even when an invoice matches."""
+        doc = self._register(customer="CUST-0001")
+        order = [("Sales Order", "name"), ("Sales Invoice", "name")]
+
+        with patch.object(type(doc), "_reconciliation_order", lambda _self: order), patch(
+            "frappe.get_value", return_value="SO-0001"
+        ):
+            invoice, sales_order = doc._get_matching_refs()
+
+        self.assertIsNone(invoice)
+        self.assertEqual(sales_order, "SO-0001")
+
+    def test_matching_refs_skip_doctypes_a_payment_cannot_settle(self):
+        """A Customer row resolves the payer but cannot be reconciled against."""
+        doc = self._register(customer="CUST-0001")
+        order = [("Customer", "name")]
+
+        with patch.object(type(doc), "_reconciliation_order", lambda _self: order):
+            self.assertEqual(doc._get_matching_refs(), (None, None))

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/test_mpesa_c2b_payment_register.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_c2b_payment_register/test_mpesa_c2b_payment_register.py
@@ -21,12 +21,30 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
     order was hardcoded, so configuring the table changed nothing.
     """
 
-    def setUp(self):
-        # get_meta hits the database on a cold cache, and these tests patch
-        # frappe.db.get_value out from under it. Warm the metas first so the
-        # patch only ever intercepts the lookups under test.
+    #: Captured once, before any patching, so the tests never need the database.
+    METAS = {}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         for doctype in ("Sales Invoice", "Sales Order", "Quotation", "Customer"):
-            frappe.get_meta(doctype)
+            cls.METAS[doctype] = frappe.get_meta(doctype)
+
+    def _metas(self):
+        """Serve real metas from the capture, and raise for anything unknown.
+
+        These tests patch frappe.db.get_value, which get_meta also uses on a
+        cold cache - and a failed lookup can clear that cache mid-test. Serving
+        metas from a pre-captured dict keeps the patch confined to the lookups
+        actually under test.
+        """
+
+        def fake_get_meta(doctype, *args, **kwargs):
+            if doctype in self.METAS:
+                return self.METAS[doctype]
+            raise frappe.DoesNotExistError(doctype)
+
+        return patch("frappe.get_meta", side_effect=fake_get_meta)
 
     def _register(self, **fields):
         doc = frappe.new_doc("Mpesa C2B Payment Register")
@@ -36,22 +54,51 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         doc.update(fields)
         return doc
 
-    def _with_priority(self, rows):
-        """Patch the configured rows without touching Mpesa Settings."""
-        return patch.object(
-            frappe.model.document.Document,
-            "_reconciliation_order",
-            lambda _self: rows,
-            create=True,
-        )
-
     def test_unconfigured_settings_keep_the_historical_order(self):
         doc = self._register()
 
-        with patch("frappe.db.get_value", return_value=None), patch(
-            "frappe.get_all", return_value=[]
+        with (
+            patch("frappe.db.get_value", return_value=None),
+            patch("frappe.get_all", return_value=[]),
         ):
-            self.assertEqual(doc._reconciliation_order(), list(DEFAULT_RECONCILIATION_ORDER))
+            self.assertEqual(
+                doc._reconciliation_order(), list(DEFAULT_RECONCILIATION_ORDER)
+            )
+
+    def test_fallback_issues_exactly_the_original_queries(self):
+        """Characterisation: an unconfigured install must query as it always did.
+
+        Pinned against the pre-change implementation, which walked a hardcoded
+        list of (doctype, customer_field, extra_filters) matching on name.
+        """
+        doc = self._register(billrefnumber="ACC-001")
+        original = [
+            ("Sales Invoice", {"name": "ACC-001", "docstatus": 1}, "customer"),
+            ("Sales Order", {"name": "ACC-001", "docstatus": 1}, "customer"),
+            (
+                "Quotation",
+                {"name": "ACC-001", "docstatus": 1, "quotation_to": "Customer"},
+                "party_name",
+            ),
+            ("Customer", {"name": "ACC-001"}, "name"),
+        ]
+
+        with (
+            self._metas(),
+            patch.object(
+                type(doc),
+                "_reconciliation_order",
+                lambda _self: list(DEFAULT_RECONCILIATION_ORDER),
+            ),
+            patch("frappe.db.get_value", return_value=None) as mock_get_value,
+        ):
+            doc._find_customer_from_billref("ACC-001")
+
+        issued = [
+            (call.args[0], call.args[1], call.args[2])
+            for call in mock_get_value.call_args_list
+        ]
+        self.assertEqual(issued, original)
 
     def test_configured_rows_replace_the_default_order(self):
         doc = self._register()
@@ -60,8 +107,9 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
             frappe._dict(target_doctype="Sales Invoice", match_field="name"),
         ]
 
-        with patch("frappe.db.get_value", return_value="898102"), patch(
-            "frappe.get_all", return_value=rows
+        with (
+            patch("frappe.db.get_value", return_value="898102"),
+            patch("frappe.get_all", return_value=rows),
         ):
             self.assertEqual(
                 doc._reconciliation_order(),
@@ -72,8 +120,9 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         doc = self._register()
         rows = [frappe._dict(target_doctype="Sales Order", match_field=None)]
 
-        with patch("frappe.db.get_value", return_value="898102"), patch(
-            "frappe.get_all", return_value=rows
+        with (
+            patch("frappe.db.get_value", return_value="898102"),
+            patch("frappe.get_all", return_value=rows),
         ):
             self.assertEqual(doc._reconciliation_order(), [("Sales Order", "name")])
 
@@ -81,9 +130,15 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         """The whole point: a non-name match_field must reach the query."""
         doc = self._register(billrefnumber="P051234567X")
 
-        with patch.object(
-            type(doc), "_reconciliation_order", lambda _self: [("Customer", "tax_id")]
-        ), patch("frappe.db.get_value", return_value="CUST-0001") as mock_get_value:
+        with (
+            self._metas(),
+            patch.object(
+                type(doc),
+                "_reconciliation_order",
+                lambda _self: [("Customer", "tax_id")],
+            ),
+            patch("frappe.db.get_value", return_value="CUST-0001") as mock_get_value,
+        ):
             doc._find_customer_from_billref("P051234567X")
 
         self.assertEqual(doc.customer, "CUST-0001")
@@ -95,9 +150,14 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         doc = self._register()
         order = [("Sales Invoice", "name"), ("Customer", "name")]
 
-        with patch.object(type(doc), "_reconciliation_order", lambda _self: order), patch(
-            "frappe.db.get_value", side_effect=["CUST-FROM-INVOICE", "CUST-FROM-CUSTOMER"]
-        ) as mock_get_value:
+        with (
+            self._metas(),
+            patch.object(type(doc), "_reconciliation_order", lambda _self: order),
+            patch(
+                "frappe.db.get_value",
+                side_effect=["CUST-FROM-INVOICE", "CUST-FROM-CUSTOMER"],
+            ) as mock_get_value,
+        ):
             doc._find_customer_from_billref("ACC-001")
 
         self.assertEqual(doc.customer, "CUST-FROM-INVOICE")
@@ -107,8 +167,10 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         doc = self._register()
         order = [("No Such Doctype", "name"), ("Customer", "name")]
 
-        with patch.object(type(doc), "_reconciliation_order", lambda _self: order), patch(
-            "frappe.db.get_value", return_value="CUST-0001"
+        with (
+            self._metas(),
+            patch.object(type(doc), "_reconciliation_order", lambda _self: order),
+            patch("frappe.db.get_value", return_value="CUST-0001"),
         ):
             doc._find_customer_from_billref("ACC-001")
 
@@ -119,8 +181,10 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         doc = self._register(customer="CUST-0001")
         order = [("Sales Order", "name"), ("Sales Invoice", "name")]
 
-        with patch.object(type(doc), "_reconciliation_order", lambda _self: order), patch(
-            "frappe.get_value", return_value="SO-0001"
+        with (
+            self._metas(),
+            patch.object(type(doc), "_reconciliation_order", lambda _self: order),
+            patch("frappe.get_value", return_value="SO-0001"),
         ):
             invoice, sales_order = doc._get_matching_refs()
 
@@ -132,5 +196,8 @@ class TestMpesaC2BPaymentRegister(FrappeTestCase):
         doc = self._register(customer="CUST-0001")
         order = [("Customer", "name")]
 
-        with patch.object(type(doc), "_reconciliation_order", lambda _self: order):
+        with (
+            self._metas(),
+            patch.object(type(doc), "_reconciliation_order", lambda _self: order),
+        ):
             self.assertEqual(doc._get_matching_refs(), (None, None))

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.json
@@ -263,7 +263,7 @@
   },
   {
    "depends_on": "eval: doc.auto_reconcile_c2b",
-   "description": "Defines the order and fields used to auto-reconcile M-Pesa C2B payments. The system matches payments sequentially based on this table (e.g., Customer by ID \u2192 Customer by PIN \u2192 Sales Invoice by ID) until a successful reconciliation. Works for PayBill transactions referencing an account.",
+   "description": "Defines the order and fields used to auto-reconcile M-Pesa C2B payments. The system matches the paid account reference sequentially against this table (e.g., Customer by ID \u2192 Customer by PIN \u2192 Sales Invoice by ID) and stops at the first hit. Leave empty to use the default order: Sales Invoice, Sales Order, Quotation, then Customer, each matched by ID. Works for PayBill transactions referencing an account.",
    "fieldname": "reconciliation_order",
    "fieldtype": "Table",
    "label": "Reconciliation Priority",


### PR DESCRIPTION
The Reconciliation Priority table on Mpesa Settings is inert. Its description promises *"The system matches payments sequentially based on this table (e.g. Customer by ID → Customer by PIN → Sales Invoice by ID) until a successful reconciliation"*, but nothing reads it:

- `match_field` is never touched by any Python. The only references are in `mpesa_settings.js`, which populates the dropdown options.
- `target_doctype` has one server-side consumer, `get_stkpush_defaults`, which uses it to fill a dropdown on the checkout page — not for matching.

Matching is hardcoded to Sales Invoice → Sales Order → Quotation → Customer, always by document name. Reordering the table or choosing a different match field changes nothing.

This walks the configured rows in order, honours `match_field`, and stops at the first hit. Rows pointing at a doctype or field that no longer exists are skipped rather than breaking the walk. Rows targeting something a payment cannot settle against still resolve the customer but are skipped when looking for an invoice or order.

## Two things kept deliberately conservative

**An install with no rows is unaffected.** The fallback reproduces the previous hardcoded order exactly, and a characterisation test asserts it issues byte-for-byte the same queries — same doctypes, same filters (`docstatus`, `quotation_to`), same customer fields, same order.

**The table stays dormant while `auto_reconcile_c2b` is off.** Worth noting for review: of the three paths that consult this ordering, only `_reconcile_payment` has ever been gated on that flag. Customer resolution on insert and reference matching before submit are not. That was harmless while the order was hardcoded, but once the table drives matching, rows left behind by someone who switched auto reconciliation off would quietly keep steering it. The table is only rendered while the flag is on, so it is now only read while the flag is on.

**Still a behaviour change worth flagging:** an install that already configured rows *and* has auto reconciliation on will find those rows now take effect, where before they were ignored. That is the intent of the field, but it is a change for anyone whose configuration differs from the default order.

Ten tests. The fallback and the dormancy guard are both mutation-checked — reverting each makes the corresponding test fail.