### PR TITLE
fix: make row STK Push button clickable in payments grid

### DIFF
--- a/frappe_mpsa_payments/public/js/sales_invoice.js
+++ b/frappe_mpsa_payments/public/js/sales_invoice.js
@@ -204,50 +204,59 @@ frappe.ui.form.on("Sales Invoice Payment", {
 	},
 });
 
+const STK_PUSH_BUTTON_HTML =
+	'<button class="btn btn-primary btn-xs stk-button">Initiate STK Push</button>';
+
+function is_stk_push_row(row) {
+	const is_mpesa_or_phone =
+		(row.mode_of_payment && row.mode_of_payment.toLowerCase().includes("mpesa")) ||
+		row.type === "Phone";
+
+	return Boolean(is_mpesa_or_phone && row.phone_number && row.amount > 0 && !row.reference_no);
+}
+
 function setup_stk_push_button_logic(frm) {
 	if (frm.is_new()) return;
 
-	const payments = frm.doc.payments || [];
+	const grid = frm.fields_dict.payments?.grid;
+	if (!grid || !grid.docfields.some((df) => df.fieldname === "initiate_stk_push")) return;
+
+	// renders the button inside an expanded grid row, where the static cell is hidden
+	grid.update_docfield_property("initiate_stk_push", "options", STK_PUSH_BUTTON_HTML);
+
 	const was_dirty = frm.doc.__unsaved;
 
-	payments.forEach((row) => {
-		const is_mpesa_or_phone =
-			(row.mode_of_payment && row.mode_of_payment.toLowerCase().includes("mpesa")) ||
-			row.type === "Phone";
-
-		if (is_mpesa_or_phone && row.phone_number && row.amount > 0 && !row.reference_no) {
-			row.initiate_stk_push = `
-        <div style="margin-top:5px;">
-          <button class="btn btn-primary btn-xs stk-button" data-row-name="${row.name}">
-            Initiate STK Push
-          </button>
-        </div>
-      `;
-		} else {
-			row.initiate_stk_push = "";
-		}
-
-		if (frm.fields_dict.payments?.grid) {
-			const grid_row = frm.fields_dict.payments.grid.grid_rows_by_docname[row.name];
-			if (grid_row) {
-				grid_row.doc.initiate_stk_push = row.initiate_stk_push;
-				grid_row.refresh_field("initiate_stk_push");
-			}
-		}
+	(frm.doc.payments || []).forEach((row) => {
+		row.initiate_stk_push = is_stk_push_row(row) ? STK_PUSH_BUTTON_HTML : "";
+		grid.grid_rows_by_docname[row.name]?.refresh_field("initiate_stk_push");
 	});
 
 	frm.doc.__unsaved = was_dirty;
 
-	setTimeout(() => {
-		$(frm.fields_dict.payments.wrapper)
-			.find(".stk-button")
-			.off("click")
-			.on("click", function () {
-				const row_name = $(this).data("row-name");
-				const row = frm.doc.payments.find((r) => r.name === row_name);
-				if (row) initiate_stk_push_child(frm, row);
-			});
-	}, 100);
+	bind_stk_push_click(frm, grid);
+}
+
+function bind_stk_push_click(frm, grid) {
+	const wrapper = grid.wrapper[0];
+	if (wrapper.dataset.stkPushBound) return;
+	wrapper.dataset.stkPushBound = "1";
+
+	// delegated, so the handler survives the grid re-rendering its cells; captured, so the
+	// cell listener that reopens the row for editing never sees the click
+	wrapper.addEventListener(
+		"click",
+		(event) => {
+			const button = event.target.closest(".stk-button");
+			if (!button) return;
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			const grid_row = grid.grid_rows.find((row) => row.wrapper?.[0].contains(button));
+			if (grid_row) initiate_stk_push_child(frm, grid_row.doc);
+		},
+		true
+	);
 }
 
 function initiate_stk_push_child(frm, row) {
@@ -258,6 +267,11 @@ function initiate_stk_push_child(frm, row) {
 
 	if (!row.phone_number) {
 		frappe.msgprint(__("Please enter a phone number to initiate STK Push."));
+		return;
+	}
+
+	if (frm.is_dirty()) {
+		frappe.msgprint(__("Save the invoice before initiating STK Push for this payment row."));
 		return;
 	}
 


### PR DESCRIPTION
## Problem

When you add a payment row to a POS Sales Invoice and set a Phone type mode of payment with a phone number and amount, the **Initiate STK Push** button appears in the grid but cannot be clicked.

There are three separate causes:

**1. The button is rendered only into the grid cell's static area.**

`setup_stk_push_button_logic` writes the button HTML into `row.initiate_stk_push`, which `grid_row.refresh_field` renders into the cell's `static_area`. Frappe's `GridRow.toggle_editable_row` hides `static_area` and shows `field_area` for whichever row is the inline-editable row. A row you have just added *is* that row, so its button measures 0x0 and is not clickable. Clicking the cell to reach it only re-runs the cell's own click listener, which reopens the row for editing, so the static area never comes back on its own.

Measured in the browser on Frappe v15.118:

```
row still in edit mode:   new-row  w=0   h=0     (a saved row: w=133 h=25)
after leaving edit mode:  new-row  w=133 h=25
```

**2. The server call cannot resolve an unsaved row.**

`get_stk_amount` and `initiate_row_stk_push` both load the child row with `frappe.get_doc("Sales Invoice Payment", name)`. For a row that has not been saved yet, `row.name` is a client-side local id, so the call fails with:

```
Sales Invoice Payment new-sales-invoice-payment-iifoucjggk not found
```

**3. The click handler is orphaned by every grid re-render.**

The handler was bound imperatively inside a `setTimeout` with `.off("click").on("click", ...)`. `GridRow.refresh_field` replaces the cell's HTML on every grid refresh, so that binding is repeatedly destroyed and re-created against detached nodes.

## Solution

- Set the `initiate_stk_push` docfield's `options` through `grid.update_docfield_property`, so the button also renders in the cell's `field_area`. It is now reachable both while the row is being edited and after it is left. The field's existing `depends_on` still governs which rows show it.
- Replace the `setTimeout` rebinding with a single delegated listener on the grid wrapper, bound once and registered in the **capture** phase. Capture means the cell's own listener never sees the click, so pressing the button no longer flips the row back into edit mode. Being delegated, it survives cell re-renders.
- Guard `initiate_stk_push_child` with `frm.is_dirty()` and show *"Save the invoice before initiating STK Push for this payment row."* instead of letting the request fail server-side. This also covers a saved row whose amount or phone number was edited but not yet persisted, since the server reads those values from the database and would otherwise push a stale amount.
- Extract the eligibility check into `is_stk_push_row` and drop the per-row `data-row-name` attribute; the row is now resolved from the clicked element's position in the grid, which works for both the static cell and the field area.

## Verification

Tested in a real browser (Playwright, Chromium) against a Frappe v15.118 / ERPNext v15.119 site with a Phone type Mode of Payment configured.

| Step | Before | After |
|---|---|---|
| Add row, fill it, still in inline edit | button 0x0, not clickable | button 133x25, hit-testable in `field-area` |
| Click while unsaved | `Sales Invoice Payment new-... not found` | `Save the invoice before initiating STK Push for this payment row.` |
| Save, then click | n/a | `get_stk_amount` then `initiate_row_stk_push` both fire |
| Does the click reopen the row for editing? | yes | no |
| Page errors | none | none |

`prettier` and `eslint` from this repo's `.pre-commit-config.yaml` both pass on the changed file.

## Notes

This targets `version-15`. The fix relies on `grid.update_docfield_property` and on Frappe's `static_area` / `field_area` toggling, so `version-16` needs its own verification before the change is forward-ported. The call is guarded with a check that the `initiate_stk_push` docfield exists, so sites without the custom field are unaffected.
